### PR TITLE
The code provides the initial version of a Ditto client library in Go.

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2020 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+package ditto
+
+import (
+	"github.com/eclipse/ditto-clients-golang/protocol"
+	MQTT "github.com/eclipse/paho.mqtt.golang"
+	"github.com/google/uuid"
+	"sync"
+	"time"
+)
+
+const (
+	defaultDisconnectTimeout = 250 * time.Millisecond
+	defaultKeepAlive         = 30 * time.Second
+)
+
+// Handler represents a callback handler that is called on each received message.
+// If the underlying transport (e.g. Hono) provides a special requestID related to the Message,
+// it's also provided to the handler so that chained responses to the ID can be later sent properly.
+type Handler func(requestID string, message *protocol.Message)
+
+// Client is the Ditto's library actual client's imple,entation.
+// It provides the connect/disconnect capabilities along with the options to subscribe/unsubscribe
+// for receiving all Ditto messages being exchanged using the underlying transport (MQTT/WS).
+type Client struct {
+	cfg          *Configuration
+	pahoClient   MQTT.Client
+	handler      Handler
+	handlersLock sync.RWMutex
+}
+
+// NewClient creates a new Client instance with the provided Configuration.
+func NewClient(cfg *Configuration) *Client {
+	client := &Client{
+		cfg: cfg,
+	}
+	return client
+}
+
+// Connect connects the client to the configured Ditto endpoint provided via the Client's Configuration at creation time.
+// If any error occurs during the connection's initiation - it's returned here.
+// An actual connection status is callbacked to the provided ConnectHandler
+// as soon as the connection is established and all Client's internal preparations are performed.
+// If the connection gets lost during runtime - the ConnectionLostHandler is notified to handle the case.
+func (client *Client) Connect() error {
+
+	pahoOpts := MQTT.NewClientOptions().
+		AddBroker(client.cfg.broker).
+		SetClientID(uuid.New().String()).
+		SetDefaultPublishHandler(client.defaultMessageHandler).
+		SetKeepAlive(client.cfg.keepAlive).
+		SetCleanSession(true).
+		SetAutoReconnect(true).
+		SetOnConnectHandler(client.clientConnectHandler).
+		SetConnectionLostHandler(client.clientConnectionLostHandler).
+		SetTLSConfig(client.cfg.tlsConfig)
+
+	if client.cfg.credentials != nil {
+		pahoOpts = pahoOpts.SetCredentialsProvider(func() (username string, password string) {
+			return client.cfg.credentials.Username, client.cfg.credentials.Password
+		})
+	}
+
+	//create and start a client using the created ClientOptions
+	client.pahoClient = MQTT.NewClient(pahoOpts)
+
+	if token := client.pahoClient.Connect(); token.Wait() && token.Error() != nil {
+		return token.Error()
+	}
+	return nil
+}
+
+// Disconnect disconnects the client from the configured Ditto endpoint.
+// A call to Disconnect will not cause a ConnectionLostHandler to be called.
+func (client *Client) Disconnect() {
+	if token := client.pahoClient.Unsubscribe(honoMQTTTopicSubscribeCommands); token.Wait() && token.Error() != nil {
+		ERROR.Printf("error while disconnecting client: %v", token.Error())
+	}
+	client.pahoClient.Disconnect(uint(client.cfg.disconnectTimeout.Milliseconds()))
+}
+
+// Reply is an auxiliary method to send replies for specific requestIDs if such has been provided along with the incoming protocol.Message.
+// The requestID must be the same as the one provided with the request protocol.Message.
+// An error is returned if the reply could not be sent for some reason.
+func (client *Client) Reply(requestID string, message *protocol.Message) error {
+	if err := client.publish(generateHonoResponseTopic(requestID, message.Status), message, 1, false); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Send sends a protocol.Message to the Client's configured Ditto endpoint.
+func (client *Client) Send(message *protocol.Message) error {
+	if err := client.publish(honoMQTTTopicPublishEvents, message, 1, false); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Subscribe ensures that all incoming Ditto messages will be transferred to the provided Handler.
+// As subscribing in Ditto is transport-specific - this is a lighweight version of a default subsciption that is applicable in the MQTT use case.
+func (client *Client) Subscribe(handler Handler) {
+	client.handlersLock.Lock()
+	defer client.handlersLock.Unlock()
+	client.handler = handler
+}
+
+// Unsubscribe ensures that protocol.Message-s will no longer be forwarded to the provided Handler.
+func (client *Client) Unsubscribe() {
+	client.handlersLock.Lock()
+	defer client.handlersLock.Unlock()
+	client.handler = nil
+}

--- a/client_config.go
+++ b/client_config.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2020 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+package ditto
+
+import (
+	"crypto/tls"
+	"time"
+)
+
+// ConnectHandler is called when a successful connection to the configured Ditto endpoint is established and
+// all Client's internal preparations are done.
+type ConnectHandler func(client *Client)
+
+// ConnectionLostHandler is called is the connection is lost during runtime.
+type ConnectionLostHandler func(client *Client, err error)
+
+// Credentials represents a user credentials for authentication used by the underlying connection (e.g. MQTT)
+type Credentials struct {
+	Username string
+	Password string
+}
+
+// Configuration provides the Client's configuration.
+type Configuration struct {
+	broker                string
+	keepAlive             time.Duration
+	disconnectTimeout     time.Duration
+	connectHandler        ConnectHandler
+	connectionLostHandler ConnectionLostHandler
+	tlsConfig             *tls.Config
+	credentials           *Credentials
+}
+
+// NewConfiguration creates a new Configuration instance.
+func NewConfiguration() *Configuration {
+	return &Configuration{
+		keepAlive:         defaultKeepAlive,
+		disconnectTimeout: defaultDisconnectTimeout,
+	}
+}
+
+// Broker provides the current MQTT broker the client is to connect to.
+func (cfg *Configuration) Broker() string {
+	return cfg.broker
+}
+
+// KeepAlive provides the keep alive connection's period
+// The default is 30 seconds.
+func (cfg *Configuration) KeepAlive() time.Duration {
+	return cfg.keepAlive
+}
+
+// DisconnectTimeout provides the timeout for disconnecting the client.
+// The default is 250 milliseconds.
+func (cfg *Configuration) DisconnectTimeout() time.Duration {
+	return cfg.disconnectTimeout
+}
+
+// Credentials provides the currently configured authentication credentials used for the underlying connection.
+func (cfg *Configuration) Credentials() *Credentials {
+	return cfg.credentials
+}
+
+// ConnectHandler provides the currently configured ConnectHandler.
+func (cfg *Configuration) ConnectHandler() ConnectHandler {
+	return cfg.connectHandler
+}
+
+// ConnectionLostHandler provides the currently configured ConnectionLostHandler.
+func (cfg *Configuration) ConnectionLostHandler() ConnectionLostHandler {
+	return cfg.connectionLostHandler
+}
+
+// TLSConfig provides the current TLS configuration for the underlying connection.
+func (cfg *Configuration) TLSConfig() *tls.Config {
+	return cfg.tlsConfig
+}
+
+// WithBroker configures the MQTT's broker the Client to connect to.
+func (cfg *Configuration) WithBroker(broker string) *Configuration {
+	cfg.broker = broker
+	return cfg
+}
+
+// WithKeepAlive configures the keep alive time period for the underlying Client's connection.
+func (cfg *Configuration) WithKeepAlive(keepAlive time.Duration) *Configuration {
+	cfg.keepAlive = keepAlive
+	return cfg
+}
+
+// WithDisconnectTimeout configures the timeout for disconnection of the Client.
+func (cfg *Configuration) WithDisconnectTimeout(disconnectTimeout time.Duration) *Configuration {
+	cfg.disconnectTimeout = disconnectTimeout
+	return cfg
+}
+
+// WithCredentials configures the credentials to be used for authentication by the underlying connection of the Client.
+func (cfg *Configuration) WithCredentials(credentials *Credentials) *Configuration {
+	cfg.credentials = credentials
+	return cfg
+}
+
+// WithConnectHandler configures the connectHandler to be notified when the Client's connection is established.
+func (cfg *Configuration) WithConnectHandler(connectHandler ConnectHandler) *Configuration {
+	cfg.connectHandler = connectHandler
+	return cfg
+}
+
+// WithConnectionLostHandler configures the connectionLostHandler to be notified is the Client's connection gets lost during rutnime.
+func (cfg *Configuration) WithConnectionLostHandler(connectionLostHandler ConnectionLostHandler) *Configuration {
+	cfg.connectionLostHandler = connectionLostHandler
+	return cfg
+}
+
+// WithTLSConfig sets the TLS configuration to be used by the Client's underlying connection.
+func (cfg *Configuration) WithTLSConfig(tlsConfig *tls.Config) *Configuration {
+	cfg.tlsConfig = tlsConfig
+	return cfg
+}

--- a/client_handlers.go
+++ b/client_handlers.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2020 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+package ditto
+
+import (
+	//import the Paho Go MQTT library
+	MQTT "github.com/eclipse/paho.mqtt.golang"
+)
+
+func (client *Client) defaultMessageHandler(mqttClient MQTT.Client, message MQTT.Message) {
+	DEBUG.Printf("unexpected message received: %v", message)
+}
+
+func (client *Client) honoMessageHandler(mqttClient MQTT.Client, message MQTT.Message) {
+	DEBUG.Printf("received Hono message for client subscription: %v", message)
+	dittoMsg, err := getMessage(message.Payload())
+	if err != nil {
+		ERROR.Printf("error getting Ditto message: %v", err)
+		return
+	}
+	requestID := extractHonoRequestId(message.Topic())
+	if requestID == "" {
+		DEBUG.Printf("no Hono request ID is available in the received message with topic: %s", message.Topic())
+	} else {
+		DEBUG.Printf("received a command from Hono with request ID: %s", requestID)
+	}
+	client.handlersLock.RLock()
+	defer client.handlersLock.RUnlock()
+	if client.handler != nil {
+		client.handler(requestID, dittoMsg)
+	}
+}

--- a/client_internal.go
+++ b/client_internal.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2020 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+package ditto
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/eclipse/ditto-clients-golang/protocol"
+	"sync"
+	"time"
+
+	//import the Paho Go MQTT library
+	MQTT "github.com/eclipse/paho.mqtt.golang"
+)
+
+const (
+	honoMQTTTopicSubscribeCommands = "command///req/#"
+	honoMQTTTopicPublishTelemetry  = "t"
+	honoMQTTTopicPublishEvents     = "e"
+)
+
+func (client *Client) clientConnectHandler(pahoClient MQTT.Client) {
+	if token := client.pahoClient.Subscribe(honoMQTTTopicSubscribeCommands, 1, client.honoMessageHandler); token.Wait() && token.Error() != nil {
+		ERROR.Printf("error subscribing to root Hono topic %s : %v", honoMQTTTopicSubscribeCommands, token.Error())
+	}
+	client.notifyClientConnected()
+}
+
+func (client *Client) notifyClientConnected() {
+	notifyChan := make(chan error, 1)
+	var notifyOnce sync.Once
+	go func() {
+		notifyOnce.Do(func() {
+			if client.cfg.connectHandler != nil {
+				client.cfg.connectHandler(client)
+			}
+		})
+		notifyChan <- nil
+	}()
+
+	select {
+	case <-notifyChan:
+		DEBUG.Println("notified for client initialization successfully")
+	case <-time.After(60 * time.Second):
+		ERROR.Printf("%v", errors.New("timed out waiting for initialization notification to be handled"))
+	}
+}
+
+func (client *Client) clientConnectionLostHandler(pahoClient MQTT.Client, err error) {
+	client.notifyClientConnectionLost(err)
+}
+
+func (client *Client) notifyClientConnectionLost(err error) {
+	notifyChan := make(chan error, 1)
+	var notifyOnce sync.Once
+	go func() {
+		notifyOnce.Do(func() {
+			if client.cfg.connectionLostHandler != nil {
+				client.cfg.connectionLostHandler(client, err)
+			}
+		})
+		notifyChan <- nil
+	}()
+
+	select {
+	case <-notifyChan:
+		DEBUG.Println("notified for client connection lost successfully")
+	case <-time.After(60 * time.Second):
+		ERROR.Printf("%v", errors.New("timed out waiting for connection lost notification to be handled"))
+	}
+}
+
+func (client *Client) publish(topic string, message *protocol.Message, qos byte, retained bool) error {
+	payload, err := json.Marshal(message)
+	if err != nil {
+		return err
+	}
+	if token := client.pahoClient.Publish(topic, qos, retained, payload); token.Wait() && token.Error() != nil {
+		return token.Error()
+	}
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/eclipse/ditto-clients-golang
+
+go 1.13
+
+require (
+	github.com/eclipse/paho.mqtt.golang v1.2.0
+	github.com/google/uuid v1.1.1
+	golang.org/x/net v0.0.0-20200707034311-ab3426394381 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,15 @@
+github.com/eclipse/paho.mqtt.golang v1.2.0 h1:1F8mhG9+aO5/xpdtFkW4SxOJB67ukuDC3t2y2qayIX0=
+github.com/eclipse/paho.mqtt.golang v1.2.0/go.mod h1:H9keYFcgq3Qr5OUJm/JZI/i6U7joQ8SYLhZwfeOo6Ts=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20200707034311-ab3426394381 h1:VXak5I6aEWmAXeQjA+QSZzlgNrpq9mjcfDemuexIKsU=
+golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/legal/NOTICE-THIRD-PARTY.md
+++ b/legal/NOTICE-THIRD-PARTY.md
@@ -1,2 +1,25 @@
 # Third-party Content
 
+## github.com/eclipse/paho.mqtt.golang (1.2.0)
+
+ * Go module: `github.com/eclipse/paho.mqtt.golang v1.2.0`
+ * License: [EPL 1.0](licenses/LICENSE.eclipse_paho_mqtt_clients_golang-1.2.0)
+ * Project: https://www.eclipse.org/paho/clients/golang/
+ * Source: https://github.com/eclipse/paho.mqtt.golang/releases/tag/v1.2.0
+
+
+## github.com/google/uuid (1.1.1)
+
+ * Go module: `github.com/google/uuid v1.1.1`
+ * License: [BSD 3-Clause "New" or "Revised"](licenses/LICENSE.google_uuid-1.1.1)
+ * Project: https://github.com/google/uuid
+ * Source: https://github.com/google/uuid/releases/tag/v1.1.1
+
+
+## golang.org/x/net (0.0.0-20200707034311-ab3426394381)
+
+ * Go module: `golang.org/x/net, 0.0.0-20200707034311-ab3426394381`
+ * License: [BSD 3-Clause "New" or "Revised"](licenses/LICENSE.golang_org_x_net-0.0.0-20200707034311-ab3426394381)
+ * Project: https://godoc.org/golang.org/x/net
+ * Source: https://github.com/golang/net/tree/ab34263943818b32f575efc978a3d24e80b04bd7
+

--- a/legal/NOTICE.md
+++ b/legal/NOTICE.md
@@ -29,7 +29,7 @@ listed source code repository logs.
 
 # Third-party Content
 
-This software includes third party content listed in [NOTICE-THIRD-PARTY.md](NOTICE-THIRD-PARTY.md)
+This software uses third party content AS-IS listed in [NOTICE-THIRD-PARTY.md](NOTICE-THIRD-PARTY.md)
 
 # Cryptography
 

--- a/legal/licenses/LICENSE.eclipse_paho_mqtt_clients_golang-1.2.0
+++ b/legal/licenses/LICENSE.eclipse_paho_mqtt_clients_golang-1.2.0
@@ -1,0 +1,70 @@
+Eclipse Public License - v 1.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+a) in the case of the initial Contributor, the initial code and documentation distributed under this Agreement, and
+b) in the case of each subsequent Contributor:
+i) changes to the Program, and
+ii) additions to the Program;
+where such changes and/or additions to the Program originate from and are distributed by that particular Contributor. A Contribution 'originates' from a Contributor if it was added to the Program by such Contributor itself or anyone acting on such Contributor's behalf. Contributions do not include additions to the Program which: (i) are separate modules of software distributed in conjunction with the Program under their own license agreement, and (ii) are not derivative works of the Program.
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are necessarily infringed by the use or sale of its Contribution alone or when combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement, including all Contributors.
+
+2. GRANT OF RIGHTS
+
+a) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, distribute and sublicense the Contribution of such Contributor, if any, and such derivative works, in source code and object code form.
+b) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed Patents to make, use, sell, offer to sell, import and otherwise transfer the Contribution of such Contributor, if any, in source code and object code form. This patent license shall apply to the combination of the Contribution and the Program if, at the time the Contribution is added by the Contributor, such addition of the Contribution causes such combination to be covered by the Licensed Patents. The patent license shall not apply to any other combinations which include the Contribution. No hardware per se is licensed hereunder.
+c) Recipient understands that although each Contributor grants the licenses to its Contributions set forth herein, no assurances are provided by any Contributor that the Program does not infringe the patent or other intellectual property rights of any other entity. Each Contributor disclaims any liability to Recipient for claims brought by any other entity based on infringement of intellectual property rights or otherwise. As a condition to exercising the rights and licenses granted hereunder, each Recipient hereby assumes sole responsibility to secure any other intellectual property rights needed, if any. For example, if a third party patent license is required to allow Recipient to distribute the Program, it is Recipient's responsibility to acquire that license before distributing the Program.
+d) Each Contributor represents that to its knowledge it has sufficient copyright rights in its Contribution, if any, to grant the copyright license set forth in this Agreement.
+3. REQUIREMENTS
+
+A Contributor may choose to distribute the Program in object code form under its own license agreement, provided that:
+
+a) it complies with the terms and conditions of this Agreement; and
+b) its license agreement:
+i) effectively disclaims on behalf of all Contributors all warranties and conditions, express and implied, including warranties or conditions of title and non-infringement, and implied warranties or conditions of merchantability and fitness for a particular purpose;
+ii) effectively excludes on behalf of all Contributors all liability for damages, including direct, indirect, special, incidental and consequential damages, such as lost profits;
+iii) states that any provisions which differ from this Agreement are offered by that Contributor alone and not by any other party; and
+iv) states that source code for the Program is available from such Contributor, and informs licensees how to obtain it in a reasonable manner on or through a medium customarily used for software exchange.
+When the Program is made available in source code form:
+
+a) it must be made available under this Agreement; and
+b) a copy of this Agreement must be included with each copy of the Program.
+Contributors may not remove or alter any copyright notices contained within the Program.
+
+Each Contributor must identify itself as the originator of its Contribution, if any, in a manner that reasonably allows subsequent Recipients to identify the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities with respect to end users, business partners and the like. While this license is intended to facilitate the commercial use of the Program, the Contributor who includes the Program in a commercial product offering should do so in a manner which does not create potential liability for other Contributors. Therefore, if a Contributor includes the Program in a commercial product offering, such Contributor ("Commercial Contributor") hereby agrees to defend and indemnify every other Contributor ("Indemnified Contributor") against any losses, damages and costs (collectively "Losses") arising from claims, lawsuits and other legal actions brought by a third party against the Indemnified Contributor to the extent caused by the acts or omissions of such Commercial Contributor in connection with its distribution of the Program in a commercial product offering. The obligations in this section do not apply to any claims or Losses relating to any actual or alleged intellectual property infringement. In order to qualify, an Indemnified Contributor must: a) promptly notify the Commercial Contributor in writing of such claim, and b) allow the Commercial Contributor to control, and cooperate with the Commercial Contributor in, the defense and any related settlement negotiations. The Indemnified Contributor may participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product offering, Product X. That Contributor is then a Commercial Contributor. If that Commercial Contributor then makes performance claims, or offers warranties related to Product X, those performance claims and warranties are such Commercial Contributor's responsibility alone. Under this section, the Commercial Contributor would have to defend claims against the other Contributors related to those performance claims and warranties, and if a court requires any other Contributor to pay any damages as a result, the Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the appropriateness of using and distributing the Program and assumes all risks associated with its exercise of rights under this Agreement , including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this Agreement, and without further action by the parties hereto, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Program itself (excluding combinations of the Program with other software or hardware) infringes such Recipient's patent(s), then such Recipient's rights granted under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to comply with any of the material terms or conditions of this Agreement and does not cure such failure in a reasonable period of time after becoming aware of such noncompliance. If all Recipient's rights under this Agreement terminate, Recipient agrees to cease use and distribution of the Program as soon as reasonably practicable. However, Recipient's obligations under this Agreement and any licenses granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in order to avoid inconsistency the Agreement is copyrighted and may only be modified in the following manner. The Agreement Steward reserves the right to publish new versions (including revisions) of this Agreement from time to time. No one other than the Agreement Steward has the right to modify this Agreement. The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation may assign the responsibility to serve as the Agreement Steward to a suitable separate entity. Each new version of the Agreement will be given a distinguishing version number. The Program (including Contributions) may always be distributed subject to the version of the Agreement under which it was received. In addition, after a new version of the Agreement is published, Contributor may elect to distribute the Program (including its Contributions) under the new version. Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives no rights or licenses to the intellectual property of any Contributor under this Agreement, whether expressly, by implication, estoppel or otherwise. All rights in the Program not expressly granted under this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the intellectual property laws of the United States of America. No party to this Agreement will bring a legal action under this Agreement more than one year after the cause of action arose. Each party waives its rights to a jury trial in any resulting litigation.

--- a/legal/licenses/LICENSE.golang_org_x_net-0.0.0-20200707034311-ab3426394381
+++ b/legal/licenses/LICENSE.golang_org_x_net-0.0.0-20200707034311-ab3426394381
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/legal/licenses/LICENSE.google_uuid-1.1.1
+++ b/legal/licenses/LICENSE.google_uuid-1.1.1
@@ -1,0 +1,27 @@
+Copyright (c) 2009,2014 Google Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2020 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+package ditto
+
+type (
+	// Logger interface allows plugging of a logger implementation that
+	// fits best the needs of the application that is to use the Ditto library
+	Logger interface {
+		Println(v ...interface{})
+		Printf(format string, v ...interface{})
+	}
+
+	// LoggerStub provides an empty default implementation
+	LoggerStub struct{}
+)
+
+func (LoggerStub) Println(v ...interface{})               {}
+func (LoggerStub) Printf(format string, v ...interface{}) {}
+
+// Levels of the library's output that can be configured during package initialization in init()
+var (
+	INFO  Logger = LoggerStub{}
+	WARN  Logger = LoggerStub{}
+	DEBUG Logger = LoggerStub{}
+	ERROR Logger = LoggerStub{}
+)

--- a/model/definition_id.go
+++ b/model/definition_id.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2020 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// DefinitionID represents an ID of a given definition entity.
+// Compliant with the Ditto specification it consists of a namespace, name and a version
+// in the form of 'namespace:name:version'.
+// The DefinitionID is used to declare a Thing's model also it is used
+// in declare the different models a Feature represents via its properties.
+type DefinitionID struct {
+	Namespace string
+	Name      string
+	Version   string
+}
+
+const definitionIdTemplate = "%s:%s:%s"
+
+// NewDefinitionIDFrom creates a new DefinitionID instance from a provided string in the form of 'namespace:name:version'.
+func NewDefinitionIDFrom(full string) *DefinitionID {
+	elements := strings.Split(full, ":")
+	return &DefinitionID{Namespace: elements[0], Name: elements[1], Version: elements[2]}
+}
+
+// NewDefinitionID creates a new DefinitionID instance with the namespace, name and version provided.
+func NewDefinitionID(namespace string, name string, version string) *DefinitionID {
+	return &DefinitionID{Namespace: namespace, Name: name, Version: version}
+}
+
+// String provides the string representation of a DefinitionID in the Ditto's specified form of 'namespace:name:version'.
+func (definitionId *DefinitionID) String() string {
+	return fmt.Sprintf(definitionIdTemplate, definitionId.Namespace, definitionId.Name, definitionId.Version)
+}
+
+func (definitionId *DefinitionID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(definitionId.String())
+}
+
+func (definitionId *DefinitionID) UnmarshalJSON(data []byte) error {
+	var defIDString = ""
+
+	if err := json.Unmarshal(data, &defIDString); err != nil {
+		return err
+	}
+	elements := strings.Split(defIDString, ":")
+	definitionId.Namespace = elements[0]
+	definitionId.Name = elements[1]
+	definitionId.Version = elements[2]
+	return nil
+}
+
+// WithNamespace sets the provided namespace to the current DefinitionID instance.
+func (definitionId *DefinitionID) WithNamespace(namespace string) *DefinitionID {
+	definitionId.Namespace = namespace
+	return definitionId
+}
+
+// WithName sets the provided name to the current DefinitionID instance.
+func (definitionId *DefinitionID) WithName(name string) *DefinitionID {
+	definitionId.Name = name
+	return definitionId
+}
+
+// WithVersion sets the provided version to the current DefinitionID instance.
+func (definitionId *DefinitionID) WithVersion(version string) *DefinitionID {
+	definitionId.Version = version
+	return definitionId
+}

--- a/model/feature.go
+++ b/model/feature.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2020 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+package model
+
+// Feature represents the Feature entity defined by the Ditto's Things specification.
+// It is used to manage all data and functionality of a Thing that can be clustered in an outlined technical context.
+type Feature struct {
+	Definition []*DefinitionID        `json:"definition,omitempty"`
+	Properties map[string]interface{} `json:"properties,omitempty"`
+}
+
+// WithDefinitionFrom is an auxiliary method to set the Feature's definition from an array of strings converted into the proper DefinitionID instances.
+func (feature *Feature) WithDefinitionFrom(definition ...string) *Feature {
+	if definition != nil {
+		feature.Definition = make([]*DefinitionID, len(definition))
+		for i, def := range definition {
+			feature.Definition[i] = NewDefinitionIDFrom(def)
+		}
+	}
+	return feature
+}
+
+// WithDefinition sets the definition of the current Feature instance to the provided set of DefinitionIDs.
+func (feature *Feature) WithDefinition(definition ...*DefinitionID) *Feature {
+	feature.Definition = definition
+	return feature
+}
+
+// WithProperties sets all properties of the current Feature instance.
+func (feature *Feature) WithProperties(properties map[string]interface{}) *Feature {
+	feature.Properties = properties
+	return feature
+}
+
+// WithProperty sets/adds a property to the current Feature instance.
+func (feature *Feature) WithProperty(id string, value interface{}) *Feature {
+	if feature.Properties == nil {
+		feature.Properties = make(map[string]interface{})
+	}
+	feature.Properties[id] = value
+	return feature
+}

--- a/model/namespaced_id.go
+++ b/model/namespaced_id.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2020 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// NamespacedID represents the namespaced entity ID defined by the Ditto specification.
+// It is a unique identifier representing a Thing compliant with the Ditto requirements:
+// - namespace and name separated by a : (colon)
+// - have a maximum length of 256 characters.
+type NamespacedID struct {
+	Namespace string
+	Name      string
+}
+
+// NewNamespacedID creates a new NamespacedID instance using the provided namespace and name.
+func NewNamespacedID(namespace string, name string) *NamespacedID {
+	return &NamespacedID{Namespace: namespace, Name: name}
+}
+
+// NewNamespacedIDFrom creates a new NamespacedID instance using the provided string in the valid form of 'namespace:name'.
+func NewNamespacedIDFrom(full string) *NamespacedID {
+	elements := strings.Split(full, ":")
+	return &NamespacedID{Namespace: elements[0], Name: strings.Join(elements[1:], ":")}
+}
+
+// String provides the string representation of the NamespacedID entity in the form of 'namespace:name'.
+func (nsID *NamespacedID) String() string {
+	return fmt.Sprintf("%s:%s", nsID.Namespace, nsID.Name)
+}
+
+func (nsID *NamespacedID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(nsID.String())
+}
+
+func (nsID *NamespacedID) UnmarshalJSON(data []byte) error {
+	var nsIDString = ""
+	if err := json.Unmarshal(data, &nsIDString); err != nil {
+		return err
+	}
+	elements := strings.Split(nsIDString, ":")
+	nsID.Namespace = elements[0]
+	nsID.Name = strings.Join(elements[1:], ":")
+	return nil
+}
+
+// WithNamespace sets the provided namespace to the current NamespacedID instance.
+func (nsID *NamespacedID) WithNamespace(namespace string) *NamespacedID {
+	nsID.Namespace = namespace
+	return nsID
+}
+
+// WithName sets the provided name to the current NamespacedID instance.
+func (nsID *NamespacedID) WithName(name string) *NamespacedID {
+	nsID.Name = name
+	return nsID
+}

--- a/model/thing.go
+++ b/model/thing.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2020 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+package model
+
+// Thing represents the Thing entity model form the Ditto's specification.
+// Things are very generic entities and are mostly used as a “handle” for multiple features belonging to this Thing.
+type Thing struct {
+	ID           *NamespacedID          `json:"thingId"`
+	PolicyID     *NamespacedID          `json:"policyId,omitempty"`
+	DefinitionID *DefinitionID          `json:"definitionId,omitempty"`
+	Attributes   map[string]interface{} `json:"attributes,omitempty"`
+	Features     map[string]*Feature    `json:"features,omitempty"`
+	Revision     int64                  `json:"revision,omitempty"`
+	Timestamp    string                 `json:"timestamp,omitempty"`
+}
+
+// WithID sets the provided NamespacedID as the current Thing's instance ID value.
+func (thing *Thing) WithID(id *NamespacedID) *Thing {
+	thing.ID = id
+	return thing
+}
+
+// WithIDFrom is an auxiliary method that sets the ID value of the current Thing instance based on the provided string n the form of 'namespace:name'.
+func (thing *Thing) WithIDFrom(id string) *Thing {
+	thing.ID = NewNamespacedIDFrom(id)
+	return thing
+}
+
+// WithDefinition sets the current Thing instance's definition to the provided value.
+func (thing *Thing) WithDefinition(definition *DefinitionID) *Thing {
+	thing.DefinitionID = definition
+	return thing
+}
+
+// WithDefinitionFrom is an auxiliary method to set the current Thing instance's definition to the provided one in the form of 'namespace:name:version'.
+func (thing *Thing) WithDefinitionFrom(definitionId string) *Thing {
+	thing.DefinitionID = NewDefinitionIDFrom(definitionId)
+	return thing
+}
+
+// WithPolicyID sets the provided Policy ID to the current Thing instance.
+func (thing *Thing) WithPolicyID(policyID *NamespacedID) *Thing {
+	thing.PolicyID = policyID
+	return thing
+}
+
+// WithPolicyIDFrom is an auxiliary method that sets the Policy ID of the current Thing instance
+// from a string NamespacedID representation in the form of 'namespace:name'.
+func (thing *Thing) WithPolicyIDFrom(policyId string) *Thing {
+	thing.PolicyID = NewNamespacedIDFrom(policyId)
+	return thing
+}
+
+// WithAttributes sets all attributes to the current Thing instance.
+func (thing *Thing) WithAttributes(attrs map[string]interface{}) *Thing {
+	thing.Attributes = attrs
+	return thing
+}
+
+// WithAttribute sets/add an attribute to the current Thing instance.
+func (thing *Thing) WithAttribute(id string, value interface{}) *Thing {
+	if thing.Attributes == nil {
+		thing.Attributes = make(map[string]interface{})
+	}
+	thing.Attributes[id] = value
+	return thing
+}
+
+// WithFeatures sets all features to the current Thing instance.
+func (thing *Thing) WithFeatures(features map[string]*Feature) *Thing {
+	thing.Features = features
+	return thing
+}
+
+// WithFeature sets/adds a Feature to the current features set of the Thing instance.
+func (thing *Thing) WithFeature(id string, value *Feature) *Thing {
+	if thing.Features == nil {
+		thing.Features = make(map[string]*Feature)
+	}
+	thing.Features[id] = value
+	return thing
+}

--- a/protocol/headers.go
+++ b/protocol/headers.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2020 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+package protocol
+
+import (
+	"encoding/json"
+)
+
+const (
+	HeaderCorrelationID    = "correlation-id"
+	HeaderResponseRequired = "response-required"
+	HeaderChannel          = "ditto-channel"
+	HeaderDryRun           = "ditto-dry-run"
+	HeaderOrigin           = "origin"
+	HeaderOriginator       = "ditto-originator"
+	HeaderETag             = "ETag"
+	HeaderIfMatch          = "If-Match"
+	HeaderIfNoneMatch      = "If-None-Match"
+	HeaderReplyTarget      = "ditto-reply-target"
+	HeaderReplyTo          = "reply-to"
+	HeaderTimeout          = "timeout"
+	HeaderSchemaVersion    = "version"
+	HeaderContentType      = "content-type"
+)
+
+// Headers represents all Ditto-specific headers along with additional HTTP/etc. headers
+// that can be applied depending on the transport used.
+// See https://www.eclipse.org/ditto/protocol-specification.html
+type Headers struct {
+	Values map[string]interface{}
+}
+
+func (h *Headers) CorrelationID() string {
+	if h.Values[HeaderCorrelationID] == nil {
+		return ""
+	}
+	return h.Values[HeaderCorrelationID].(string)
+}
+
+func (h *Headers) Timeout() string {
+	if h.Values[HeaderTimeout] == nil {
+		return ""
+	}
+	return h.Values[HeaderTimeout].(string)
+}
+
+func (h *Headers) IsResponseRequired() bool {
+	if h.Values[HeaderResponseRequired] == nil {
+		return false
+	}
+	return h.Values[HeaderResponseRequired].(bool)
+}
+func (h *Headers) Channel() string {
+	if h.Values[HeaderChannel] == nil {
+		return ""
+	}
+	return h.Values[HeaderChannel].(string)
+}
+func (h *Headers) IsDryRun() bool {
+	if h.Values[HeaderDryRun] == nil {
+		return false
+	}
+	return h.Values[HeaderDryRun].(bool)
+}
+func (h *Headers) Origin() string {
+	if h.Values[HeaderOrigin] == nil {
+		return ""
+	}
+	return h.Values[HeaderOrigin].(string)
+}
+func (h *Headers) Originator() string {
+	if h.Values[HeaderOriginator] == nil {
+		return ""
+	}
+	return h.Values[HeaderOriginator].(string)
+}
+func (h *Headers) ETag() string {
+	if h.Values[HeaderETag] == nil {
+		return ""
+	}
+	return h.Values[HeaderETag].(string)
+}
+func (h *Headers) IfMatch() string {
+	if h.Values[HeaderIfMatch] == nil {
+		return ""
+	}
+	return h.Values[HeaderIfMatch].(string)
+}
+func (h *Headers) IfNoneMatch() string {
+	if h.Values[HeaderIfNoneMatch] == nil {
+		return ""
+	}
+	return h.Values[HeaderIfNoneMatch].(string)
+}
+func (h *Headers) ReplyTarget() int64 {
+	if h.Values[HeaderReplyTarget] == nil {
+		return 0
+	}
+	return h.Values[HeaderReplyTarget].(int64)
+}
+func (h *Headers) ReplyTo() string {
+	if h.Values[HeaderReplyTo] == nil {
+		return ""
+	}
+	return h.Values[HeaderReplyTo].(string)
+}
+func (h *Headers) Version() int64 {
+	if h.Values[HeaderSchemaVersion] == nil {
+		return 0
+	}
+	return h.Values[HeaderSchemaVersion].(int64)
+}
+func (h *Headers) ContentType() string {
+	if h.Values[HeaderContentType] == nil {
+		return ""
+	}
+	return h.Values[HeaderContentType].(string)
+}
+func (h *Headers) Generic(id string) interface{} {
+	return h.Values[id]
+}
+
+func (h *Headers) MarshalJSON() ([]byte, error) {
+	return json.Marshal(h.Values)
+}
+
+func (h *Headers) UnmarshalJSON(data []byte) error {
+	var v map[string]interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	h.Values = v
+	return nil
+}

--- a/protocol/headers_opts.go
+++ b/protocol/headers_opts.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2020 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+package protocol
+
+// HeaderOpt represents a specific Headers option that can be applied to the Headers instance
+// resulting in changing the value of a specific header of a set of headers.
+type HeaderOpt func(headers *Headers) error
+
+func applyOptsHeader(headers *Headers, opts ...HeaderOpt) error {
+	for _, o := range opts {
+		if err := o(headers); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// NewHeaders returns a new Headers instance.
+func NewHeaders(opts ...HeaderOpt) *Headers {
+	res := &Headers{}
+	res.Values = make(map[string]interface{})
+	if err := applyOptsHeader(res, opts...); err != nil {
+		return nil
+	}
+	return res
+}
+
+func WithCorrelationID(correlationId string) HeaderOpt {
+	return func(headers *Headers) error {
+		headers.Values[HeaderCorrelationID] = correlationId
+		return nil
+	}
+}
+func WithReplyTo(replyTo string) HeaderOpt {
+	return func(headers *Headers) error {
+		headers.Values[HeaderReplyTo] = replyTo
+		return nil
+	}
+}
+func WithReplyTarget(replyTarget string) HeaderOpt {
+	return func(headers *Headers) error {
+		headers.Values[HeaderReplyTarget] = replyTarget
+		return nil
+	}
+}
+
+func WithChannel(channel string) HeaderOpt {
+	return func(headers *Headers) error {
+		headers.Values[HeaderChannel] = channel
+		return nil
+	}
+}
+
+func WithResponseRequired(isResponseRequired bool) HeaderOpt {
+	return func(headers *Headers) error {
+		headers.Values[HeaderResponseRequired] = isResponseRequired
+		return nil
+	}
+}
+
+func WithOriginator(dittoOriginator string) HeaderOpt {
+	return func(headers *Headers) error {
+		headers.Values[HeaderOriginator] = dittoOriginator
+		return nil
+	}
+}
+
+func WithOrigin(origin string) HeaderOpt {
+	return func(headers *Headers) error {
+		headers.Values[HeaderOrigin] = origin
+		return nil
+	}
+}
+func WithDryRun(isDryRun bool) HeaderOpt {
+	return func(headers *Headers) error {
+		headers.Values[HeaderDryRun] = isDryRun
+		return nil
+	}
+}
+
+func WithETag(eTag string) HeaderOpt {
+	return func(headers *Headers) error {
+		headers.Values[HeaderETag] = eTag
+		return nil
+	}
+}
+
+func WithIfMatch(ifMatch string) HeaderOpt {
+	return func(headers *Headers) error {
+		headers.Values[HeaderIfMatch] = ifMatch
+		return nil
+	}
+}
+
+func WithIfNoneMatch(ifNoneMatch string) HeaderOpt {
+	return func(headers *Headers) error {
+		headers.Values[HeaderIfNoneMatch] = ifNoneMatch
+		return nil
+	}
+}
+
+func WithTimeout(timeout string) HeaderOpt {
+	return func(headers *Headers) error {
+		headers.Values[HeaderTimeout] = timeout
+		return nil
+	}
+}
+func WithSchemaVersion(schemaVersion string) HeaderOpt {
+	return func(headers *Headers) error {
+		headers.Values[HeaderSchemaVersion] = schemaVersion
+		return nil
+	}
+}
+
+func WithContentType(contentType string) HeaderOpt {
+	return func(headers *Headers) error {
+		headers.Values[HeaderContentType] = contentType
+		return nil
+	}
+}
+
+func WithGeneric(headerID string, value interface{}) HeaderOpt {
+	return func(headers *Headers) error {
+		headers.Values[headerID] = value
+		return nil
+	}
+}

--- a/protocol/message.go
+++ b/protocol/message.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2020 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+package protocol
+
+// Message represents the Ditto's Envelope specification. As a Ditto's message consists of an envelope along with a Ditto-compliant
+// payload, the structure is to be used as a ready to use Ditto message.
+type Message struct {
+	Topic     *Topic      `json:"topic"`
+	Headers   *Headers    `json:"headers,omitempty"`
+	Path      string      `json:"path"`
+	Value     interface{} `json:"value,omitempty"`
+	Fields    string      `json:"fields,omitempty"`
+	Extra     interface{} `json:"extra,omitempty"`
+	Status    int         `json:"status,omitempty"`
+	Revision  int64       `json:"revision,omitempty"`
+	Timestamp string      `json:"timestamp,omitempty"`
+}
+
+// WithTopic sets the topic of the Message.
+func (msg *Message) WithTopic(topic *Topic) *Message {
+	msg.Topic = topic
+	return msg
+}
+
+// WithHeaders sets the Headers of the Message.
+func (msg *Message) WithHeaders(headers *Headers) *Message {
+	msg.Headers = headers
+	return msg
+}
+
+// WithPath sets the Ditto path of the Message.
+func (msg *Message) WithPath(path string) *Message {
+	msg.Path = path
+	return msg
+}
+
+// WithValue sets the Ditto value of the Message.
+func (msg *Message) WithValue(value interface{}) *Message {
+	msg.Value = value
+	return msg
+}
+
+// WithFields sets the fields of the Message as defined by the Ditto protocol specification.
+func (msg *Message) WithFields(fields string) *Message {
+	msg.Fields = fields
+	return msg
+}
+
+// WithExtra sets any extra Message configurations as defined by the Ditto protocol specification.
+func (msg *Message) WithExtra(extra interface{}) *Message {
+	msg.Extra = extra
+	return msg
+}
+
+// WithStatus sets the Message's status based on the HTTP codes available.
+func (msg *Message) WithStatus(status int) *Message {
+	msg.Status = status
+	return msg
+}
+
+// WithRevision sets the current revision number of an entity this Message refers to.
+func (msg *Message) WithRevision(revision int64) *Message {
+	msg.Revision = revision
+	return msg
+}
+
+// WithTimestamp sets the timestamp of the Message.
+func (msg *Message) WithTimestamp(timestamp string) *Message {
+	msg.Timestamp = timestamp
+	return msg
+}

--- a/protocol/things/commands.go
+++ b/protocol/things/commands.go
@@ -1,0 +1,185 @@
+// Copyright (c) 2020 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+package things
+
+import (
+	"fmt"
+	"github.com/eclipse/ditto-clients-golang/model"
+	"github.com/eclipse/ditto-clients-golang/protocol"
+)
+
+const (
+	pathThing                        = "/"
+	pathThingDefinition              = "/definition"
+	pathThingPolicyID                = "/policyId"
+	pathThingFeatures                = "/features"
+	pathThingAttributes              = "/attributes"
+	pathThingAttributeFormat         = pathThingAttributes + "/%s"
+	pathThingFeatureFormat           = pathThingFeatures + "/%s"
+	pathThingFeatureDefinitionFormat = pathThingFeatureFormat + "/definition"
+	pathThingFeaturePropertiesFormat = pathThingFeatureFormat + "/properties"
+	pathThingFeaturePropertyFormat   = pathThingFeaturePropertiesFormat + "/%s"
+)
+
+// Command represents a message entity defined by the Ditto protocol for the Things group that defines the execution of a certain action.
+// This is a special Message that is always bound to a specific Thing instance along with providing the capabilities to configure:
+// - the type of the action it will signal for execution - Create, Modify, Retrieve, Delete
+// - the channel it will be sent - Twin, Live
+// - the entity it will affect - the whole Thing (the default), all features of the Thing (Features),
+//                               a single Feature of the Thing (Feature), all attributes of the Thing (Attributes) or
+//                               a single attribute of the Thing (Attribute), the Thing's policy (PolicyID)
+//                               or the Thing's definition (Definition).
+// Note: Only one action can be configured to the command - if using the methods for configuring it - only the last one applies.
+// Note: Only one channel can be configured to the command - if using the methods for configuring it - only the last one applies.
+// Note: Only one entity that will b affected by the command can be configured - if using the methods for configuring it - only the last one applies.
+type Command struct {
+	Topic   *protocol.Topic
+	Path    string
+	Payload interface{}
+}
+
+// NewCommand creates a new Command instance for the defined by the provided NamespacedID Thing.
+func NewCommand(thingID *model.NamespacedID) *Command {
+	return &Command{
+		Topic: (&protocol.Topic{}).
+			WithNamespace(thingID.Namespace).
+			WithEntityID(thingID.Name).
+			WithGroup(protocol.GroupThings).
+			WithChannel(protocol.ChannelTwin).
+			WithCriterion(protocol.CriterionCommands),
+		Path: pathThing,
+	}
+}
+
+// Create creates a new Thing entity based on the provided information.
+func (cmd *Command) Create(thing *model.Thing) *Command {
+	cmd.Topic.WithAction(protocol.ActionCreate)
+	cmd.Payload = thing
+	return cmd
+}
+
+// Modify sets the action of the command instance accordingly.
+// The provided payload must be the new value to be used for modification
+// compliant with the (part of) the Thing it is to be applied to.
+func (cmd *Command) Modify(payload interface{}) *Command {
+	cmd.Topic.WithAction(protocol.ActionModify)
+	cmd.Payload = payload
+	return cmd
+}
+
+// Retrieve sets the action of the command instance accordingly.
+// If thingIDs are provided the response will contain the information for these Things only.
+// Further Headers can be added via the Message method to adjust the response even more.
+// The topic placeholder for the Thing ID's namespace and/or name can be used to perform the multiple Things request, e.g.:
+// '_:_', '_:thing.id' are valid Thing NamespacedIDs to perform the multiple Things retrieve call.
+func (cmd *Command) Retrieve(thingIDs ...model.NamespacedID) *Command {
+	cmd.Topic.WithAction(protocol.ActionRetrieve)
+	if thingIDs != nil && len(thingIDs) > 0 {
+		var thingIDsStruct interface{}
+		thingIDsArray := make([]string, len(thingIDs))
+		for i, id := range thingIDs {
+			thingIDsArray[i] = id.String()
+		}
+		thingIDsStruct = struct {
+			ThingIDs []string `json:"thingIds"`
+		}{
+			ThingIDs: thingIDsArray,
+		}
+		cmd.Payload = thingIDsStruct
+	}
+	return cmd
+}
+
+// Delete sets the action of the command instance accordingly.
+func (cmd *Command) Delete() *Command {
+	cmd.Topic.WithAction(protocol.ActionDelete)
+	return cmd
+}
+
+// PolicyID configures the command to affect the Thing's Policy.
+func (cmd *Command) PolicyID() *Command {
+	cmd.Path = pathThingPolicyID
+	return cmd
+}
+
+// Definition configures the command to affect the Thing's definition.
+func (cmd *Command) Definition() *Command {
+	cmd.Path = pathThingDefinition
+	return cmd
+}
+
+// Attributes configures the command to affect the Thing's attributes.
+func (cmd *Command) Attributes() *Command {
+	cmd.Path = pathThingAttributes
+	return cmd
+}
+
+// Attribute configures the command to affect a specified by the provided attributeID attribute of the Thing.
+func (cmd *Command) Attribute(attributeID string) *Command {
+	cmd.Path = fmt.Sprintf(pathThingAttributeFormat, attributeID)
+	return cmd
+}
+
+// Features configures the command to affect all the features of the Thing.
+func (cmd *Command) Features() *Command {
+	cmd.Path = pathThingFeatures
+	return cmd
+}
+
+// Feature configures the command to affect a specified by the provided featureID feature of the Thing.
+func (cmd *Command) Feature(featureID string) *Command {
+	cmd.Path = fmt.Sprintf(pathThingFeatureFormat, featureID)
+	return cmd
+}
+
+// FeatureDefinition configures the command to affect the definition of a specified by the provided featureID feature of the Thing.
+func (cmd *Command) FeatureDefinition(featureID string) *Command {
+	cmd.Path = fmt.Sprintf(pathThingFeatureDefinitionFormat, featureID)
+	return cmd
+}
+
+// FeatureProperties configures the command to affect all properties of a specified by the provided featureID feature of the Thing.
+func (cmd *Command) FeatureProperties(featureID string) *Command {
+	cmd.Path = fmt.Sprintf(pathThingFeaturePropertiesFormat, featureID)
+	return cmd
+}
+
+// FeatureProperty configures the command to affect a specified property via the provided propertyID of a specified by the provided featureID feature of the Thing.
+func (cmd *Command) FeatureProperty(featureID, propertyID string) *Command {
+	cmd.Path = fmt.Sprintf(pathThingFeaturePropertyFormat, featureID, propertyID)
+	return cmd
+}
+
+// Live configures the channel of the command accordingly.
+func (cmd *Command) Live() *Command {
+	cmd.Topic.WithChannel(protocol.ChannelLive)
+	return cmd
+}
+
+// Twin configures the channel of the command accordingly.
+func (cmd *Command) Twin() *Command {
+	cmd.Topic.WithChannel(protocol.ChannelTwin)
+	return cmd
+}
+
+// Message generates the Ditto message applying all configurations and optionally all Headers provided.
+func (cmd *Command) Message(headerOpts ...protocol.HeaderOpt) *protocol.Message {
+	msg := &protocol.Message{
+		Topic: cmd.Topic,
+		Path:  cmd.Path,
+		Value: cmd.Payload,
+	}
+	if headerOpts != nil {
+		msg.Headers = protocol.NewHeaders(headerOpts...)
+	}
+	return msg
+}

--- a/protocol/things/events.go
+++ b/protocol/things/events.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2020 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+package things
+
+import (
+	"fmt"
+	"github.com/eclipse/ditto-clients-golang/model"
+	"github.com/eclipse/ditto-clients-golang/protocol"
+)
+
+// Event represents a message entity defined by the Ditto protocol for the Things group that defines a notification for a change that happened.
+// This is a special Message that is always bound to a specific Thing instance along with providing the capabilities to configure:
+// - the type of the change that happened - Created, Modified, Deleted
+// - the channel used for the notification - Twin, Live
+// - the entity that was affected - the whole Thing (the default), all features of the Thing (Features),
+//                               a single Feature of the Thing (Feature), all attributes of the Thing (Attributes) or
+//                               a single attribute of the Thing (Attribute), the Thing's policy (PolicyID)
+//                               or the Thing's definition (Definition).
+// Note: Only one change type can be configured to the event - if using the methods for configuring it - only the last one applies.
+// Note: Only one channel can be configured to the event - if using the methods for configuring it - only the last one applies.
+// Note: Only one entity that will b affected by the event can be configured - if using the methods for configuring it - only the last one applies.
+type Event struct {
+	Topic   *protocol.Topic
+	Path    string
+	Payload interface{}
+}
+
+// NewEvent creates a new Event instance for the defined by the provided NamespacedID Thing.
+func NewEvent(thingID *model.NamespacedID) *Event {
+	return &Event{
+		Topic: (&protocol.Topic{}).
+			WithNamespace(thingID.Namespace).
+			WithEntityID(thingID.Name).
+			WithGroup(protocol.GroupThings).
+			WithChannel(protocol.ChannelTwin).
+			WithCriterion(protocol.CriterionEvents),
+		Path: pathThing,
+	}
+}
+
+// Created configures the Event to notify for a Thing that has been created using the provided payload instance.
+func (event *Event) Created(thing *model.Thing) *Event {
+	event.Topic.WithAction(protocol.ActionCreated)
+	event.Payload = thing
+	return event
+}
+
+// Modified configures the Event to notify for a modification with a new value applied defined by the provided payload.
+func (event *Event) Modified(payload interface{}) *Event {
+	event.Topic.WithAction(protocol.ActionModified)
+	event.Payload = payload
+	return event
+}
+
+// Deleted configures the Event to notify for a deletion of a Thing or parts of the content it holds.
+func (event *Event) Deleted() *Event {
+	event.Topic.WithAction(protocol.ActionDeleted)
+	return event
+}
+
+// PolicyID configures the Event to notify for a change in the Thing's policy.
+func (event *Event) PolicyID() *Event {
+	event.Path = pathThingPolicyID
+	return event
+}
+
+// Definition configures the Event to notify for a change in the Thing's definition.
+func (event *Event) Definition() *Event {
+	event.Path = pathThingDefinition
+	return event
+}
+
+// Attributes configures the Event to notify for a change in the Thing's attributes.
+func (event *Event) Attributes() *Event {
+	event.Path = pathThingAttributes
+	return event
+}
+
+// Attribute configures the Event to notify for a change in the Thing's attribute defined by the provided attributeID.
+func (event *Event) Attribute(attributeID string) *Event {
+	event.Path = fmt.Sprintf(pathThingAttributeFormat, attributeID)
+	return event
+}
+
+// Features configures the Event to notify for a change in the Thing's features.
+func (event *Event) Features() *Event {
+	event.Path = pathThingFeatures
+	return event
+}
+
+// Feature configures the Event to notify for a change in the Thing's feature defined by the provided featureID.
+func (event *Event) Feature(featureID string) *Event {
+	event.Path = fmt.Sprintf(pathThingFeatureFormat, featureID)
+	return event
+}
+
+// FeatureDefinition configures the Event to notify for a change in the Thing's feature's definition for the feature defined by the provided featureID.
+func (event *Event) FeatureDefinition(featureID string) *Event {
+	event.Path = fmt.Sprintf(pathThingFeatureDefinitionFormat, featureID)
+	return event
+}
+
+// FeatureProperties configures the Event to notify for a change in the Thing's feature's properties of the feature defined by the provided featureID.
+func (event *Event) FeatureProperties(featureID string) *Event {
+	event.Path = fmt.Sprintf(pathThingFeaturePropertiesFormat, featureID)
+	return event
+}
+
+// FeatureProperty configures the Event to notify for a change in the Thing's feature's property defined by the provided featureID and propertyID.
+func (event *Event) FeatureProperty(featureID, propertyID string) *Event {
+	event.Path = fmt.Sprintf(pathThingFeaturePropertyFormat, featureID, propertyID)
+	return event
+}
+
+// Live configures the channel of the Event accordingly.
+func (event *Event) Live() *Event {
+	event.Topic.WithChannel(protocol.ChannelLive)
+	return event
+}
+
+// Twin configures the channel of the Event accordingly.
+func (event *Event) Twin() *Event {
+	event.Topic.WithChannel(protocol.ChannelTwin)
+	return event
+}
+
+// Message generates the Ditto message applying all configurations and optionally all Headers provided.
+func (event *Event) Message(headerOpts ...protocol.HeaderOpt) *protocol.Message {
+	msg := &protocol.Message{
+		Topic: event.Topic,
+		Path:  event.Path,
+		Value: event.Payload,
+	}
+	if headerOpts != nil {
+		msg.Headers = protocol.NewHeaders(headerOpts...)
+	}
+	return msg
+}

--- a/protocol/things/messages.go
+++ b/protocol/things/messages.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2020 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+package things
+
+import (
+	"fmt"
+	"github.com/eclipse/ditto-clients-golang/model"
+	"github.com/eclipse/ditto-clients-golang/protocol"
+)
+
+const (
+	inbox              = "inbox"
+	outbox             = "outbox"
+	pathMessagesFormat = "%s/%s/messages/%s"
+)
+
+// Message represents a message entity defined by the Ditto protocol for the Things group that defines an instant communication with the underlying device/implementation.
+// This is a special Message that is always bound to a specific Thing instance, it's always exchanged vie the
+// Live communication channel and it provides the capabilities to configure:
+// - the type of the communication - Inbox, Outbox
+// - the entity that was affected - the whole Thing (the default) or a single Feature of the Thing (Feature).
+// Note: Only one communication type can be configured to the live message - if using the methods for configuring it - only the last one applies.
+// Note: Only one entity that the message targts can be configured to the live message - if using the methods for configuring it - only the last one applies.
+type Message struct {
+	Topic                *protocol.Topic
+	Subject              string
+	Mailbox              string
+	AddressedPartOfThing string
+	Payload              interface{}
+}
+
+// NewMessage creates a new Message instance for the defined by the provided NamespacedID Thing.
+func NewMessage(thingID *model.NamespacedID) *Message {
+	return &Message{
+		Topic: (&protocol.Topic{}).
+			WithNamespace(thingID.Namespace).
+			WithEntityID(thingID.Name).
+			WithGroup(protocol.GroupThings).
+			WithChannel(protocol.ChannelLive).
+			WithCriterion(protocol.CriterionMessages),
+		AddressedPartOfThing: "",
+	}
+}
+
+// Inbox configures the live Message to be sent to the inbox of the target entity, i.e. it defines an incoming communication.
+// The Message is configured to serve only one subject - the one provided.
+func (msg *Message) Inbox(subject string) *Message {
+	msg.Topic.WithAction(protocol.TopicAction(subject))
+	msg.Subject = subject
+	msg.Mailbox = inbox
+	return msg
+}
+
+// Outbox configures the live Message to be sent to the outbox of the target entity, i.e. it defines an outgoing communication.
+// The Message is configured to serve only one subject - the one provided.
+func (msg *Message) Outbox(subject string) *Message {
+	msg.Topic.WithAction(protocol.TopicAction(subject))
+	msg.Subject = subject
+	msg.Mailbox = outbox
+	return msg
+}
+
+// WithPayload sets the data to be sent in the message, i.e. its content.
+func (msg *Message) WithPayload(payload interface{}) *Message {
+	msg.Payload = payload
+	return msg
+}
+
+// Feature configures the Message's target to be the specified by the featureID Thing's Feature.
+func (msg *Message) Feature(featureID string) *Message {
+	msg.AddressedPartOfThing = fmt.Sprintf(pathThingFeatureFormat, featureID)
+	return msg
+}
+
+// Message generates the Ditto message applying all configurations and optionally all Headers provided.
+func (msg *Message) Message(headerOpts ...protocol.HeaderOpt) *protocol.Message {
+	res := &protocol.Message{
+		Topic: msg.Topic,
+		Path:  fmt.Sprintf(pathMessagesFormat, msg.AddressedPartOfThing, msg.Mailbox, msg.Subject),
+		Value: msg.Payload,
+	}
+	if headerOpts != nil {
+		res.Headers = protocol.NewHeaders(headerOpts...)
+	}
+	return res
+}

--- a/protocol/topic.go
+++ b/protocol/topic.go
@@ -1,0 +1,163 @@
+// Copyright (c) 2020 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+package protocol
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// TopicCriterion is a representation of the defined by Ditto topic criterion options.
+type TopicCriterion string
+
+const (
+	CriterionCommands TopicCriterion = "commands"
+	CriterionEvents   TopicCriterion = "events"
+	CriterionSearch   TopicCriterion = "search"
+	CriterionMessages TopicCriterion = "messages"
+	CriterionErrors   TopicCriterion = "errors"
+)
+
+// TopicChannel is a representation of the defined by Ditto topic channel options.
+type TopicChannel string
+
+const (
+	ChannelTwin TopicChannel = "twin"
+	ChannelLive TopicChannel = "live"
+)
+
+// TopicAction is a representation of the defined by Ditto topic action options.
+type TopicAction string
+
+const (
+	ActionCreate    TopicAction = "create"
+	ActionCreated   TopicAction = "created"
+	ActionModify    TopicAction = "modify"
+	ActionModified  TopicAction = "modified"
+	ActionDelete    TopicAction = "delete"
+	ActionDeleted   TopicAction = "deleted"
+	ActionRetrieve  TopicAction = "retrieve"
+	ActionSubscribe TopicAction = "subscribe"
+	ActionRequest   TopicAction = "request"
+	ActionCancel    TopicAction = "cancel"
+	ActionNext      TopicAction = "next"
+	ActionComplete  TopicAction = "complete"
+	ActionFailed    TopicAction = "failed"
+)
+
+// TopicGroup is a representation of the defined by Ditto topic group options.
+type TopicGroup string
+
+const (
+	GroupThings   TopicGroup = "things"
+	GroupPolicies TopicGroup = "policies"
+)
+
+// TopicPlaceholder can be used in the context of "any" for things namespaces and IDs in the retrieve topics.
+const TopicPlaceholder = "_"
+
+const (
+	topicFormatThings   = "%s/%s/%s/%s/%s/%s"
+	topicFormatPolicies = "%s/%s/%s/%s/%s"
+)
+
+// Topic represents the Ditto protocol's Topic entity. It's represented in the form of:
+// <namespace>/<entityID>/<group>/<channel>/<criterion>/<action>.
+// Each of the components is configurable based on the Ditto's specification for the specific group and/or channel/criterion/etc.
+type Topic struct {
+	Namespace string
+	EntityID  string
+	Group     TopicGroup
+	Channel   TopicChannel
+	Criterion TopicCriterion
+	Action    TopicAction
+}
+
+// String provides the string representation of a Topic entity.
+func (topic *Topic) String() string {
+	switch topic.Group {
+	case GroupThings:
+		return fmt.Sprintf(topicFormatThings, topic.Namespace, topic.EntityID, topic.Group, topic.Channel, topic.Criterion, topic.Action)
+	case GroupPolicies:
+		return fmt.Sprintf(topicFormatPolicies, topic.Namespace, topic.EntityID, topic.Group, topic.Criterion, topic.Action)
+	}
+	return ""
+}
+
+func (topic *Topic) MarshalJSON() ([]byte, error) {
+	return json.Marshal(topic.String())
+}
+
+func (topic *Topic) UnmarshalJSON(data []byte) error {
+	var v string
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	elements := strings.Split(v, "/")
+	index := 0
+	topic.Namespace = elements[index]
+	index++
+	topic.EntityID = elements[index]
+	index++
+	topic.Group = TopicGroup(elements[index])
+	index++
+	switch topic.Group {
+	case GroupThings:
+		topic.Channel = TopicChannel(elements[index])
+		index++
+	case GroupPolicies:
+		// skip channel - not supported for policies group
+	}
+	topic.Criterion = TopicCriterion(elements[index])
+	// TODO action is stated to be optional but none of the groups accepts a topic without action - will we support it as optional?
+	index++
+	topic.Action = TopicAction(elements[index])
+
+	return nil
+}
+
+// WithNamespace configures the namespace of the Topic.
+func (topic *Topic) WithNamespace(ns string) *Topic {
+	topic.Namespace = ns
+	return topic
+}
+
+// WithEntityID configures the entity ID of the Topic.
+func (topic *Topic) WithEntityID(entityID string) *Topic {
+	topic.EntityID = entityID
+	return topic
+}
+
+// WithGroup configures the TopicGroup of the Topic.
+func (topic *Topic) WithGroup(group TopicGroup) *Topic {
+	topic.Group = group
+	return topic
+}
+
+// WithChannel configures the TopicChannel of the Topic.
+func (topic *Topic) WithChannel(channel TopicChannel) *Topic {
+	topic.Channel = channel
+	return topic
+}
+
+// WithCriterion configures the TopicCriterion of the Topic.
+func (topic *Topic) WithCriterion(criterion TopicCriterion) *Topic {
+	topic.Criterion = criterion
+	return topic
+}
+
+// WithAction configures the TopicAction of the Topic.
+func (topic *Topic) WithAction(action TopicAction) *Topic {
+	topic.Action = action
+	return topic
+}

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2020 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0
+//
+// SPDX-License-Identifier: EPL-2.0
+
+package ditto
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/eclipse/ditto-clients-golang/protocol"
+	"regexp"
+)
+
+var regexHonoMQTTTopicRequest, _ = regexp.Compile("^command///req/([^/]+)/([^/]+)$")
+
+const (
+	honoMQTTTopicCommandResponseFormat = "command///res/%s/%d"
+)
+
+func extractHonoRequestId(honoTopic string) string {
+	if regexHonoMQTTTopicRequest.MatchString(honoTopic) {
+		reqIdInfo := regexHonoMQTTTopicRequest.FindStringSubmatch(honoTopic)
+		return reqIdInfo[1]
+	}
+	return ""
+}
+
+func generateHonoResponseTopic(requestID string, status int) string {
+	return fmt.Sprintf(honoMQTTTopicCommandResponseFormat, requestID, status)
+}
+
+func getMessage(mqttPayload []byte) (*protocol.Message, error) {
+	env := &protocol.Message{}
+	if err := json.Unmarshal(mqttPayload, env); err != nil {
+		return nil, err
+	}
+	return env, nil
+}


### PR DESCRIPTION
It's an implementation based on Hono (over MQTT) that covers the key Ditto aspects:
> Ditto models - Things, Features and entity identification
> Ditto protocol abstractions - Envelopes, Topics, Payloads
> Ditto protocol Things group support - messages/commands/events
It also provides the means needed for Hono specifics for Command & Control, Telemetry/Events handling.

Signed-off-by: Konstantina Gramatova <konstantina.gramatova@bosch.io>