### PR TITLE
Fixed invalid Topic field name for entity - EntityID->EntityName.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ With this configuration a client instance could be created.
 ```go
 client = ditto.NewClient(config)
 ```
-**_NOTE:_** In some cases an external Paho instance could be provided for the communication. If this is the case, there is a ditto.NewClientMqtt() create function available.
+**_NOTE:_** In some cases an external Paho instance could be provided for the communication. If this is the case, there is a ditto.NewClientMQTT() create function available.
 
 After you have configured and created your client instance, it's ready to be connected.
 ```go

--- a/client_handlers.go
+++ b/client_handlers.go
@@ -37,7 +37,7 @@ func (client *Client) honoMessageHandler(mqttClient MQTT.Client, message MQTT.Me
 		ERROR.Printf("error getting Ditto message: %v", err)
 		return
 	}
-	requestID := extractHonoRequestId(message.Topic())
+	requestID := extractHonoRequestID(message.Topic())
 	if requestID == "" {
 		DEBUG.Printf("no request ID is available in the received message with topic: %s", message.Topic())
 	} else {

--- a/client_handlers_test.go
+++ b/client_handlers_test.go
@@ -28,15 +28,15 @@ func TestHonoMessageHandlingSuccess(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	mockMqttMessage := mock.NewMockMessage(mockCtrl)
+	mockMQTTMessage := mock.NewMockMessage(mockCtrl)
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 
 	unitUnderTest := NewClient(&Configuration{})
 	validMessage := []byte("{\"test\": 15}")
-	requestId := "expected"
-	topic := createTopic(requestId)
+	requestID := "expected"
+	topic := createTopic(requestID)
 
 	expectedEnvelope, _ := getEnvelope(validMessage)
 
@@ -45,11 +45,11 @@ func TestHonoMessageHandlingSuccess(t *testing.T) {
 		wg.Done()
 	}
 
-	mockMqttMessage.EXPECT().Payload().Return(validMessage)
-	mockMqttMessage.EXPECT().Topic().Return(topic)
+	mockMQTTMessage.EXPECT().Payload().Return(validMessage)
+	mockMQTTMessage.EXPECT().Topic().Return(topic)
 
 	unitUnderTest.Subscribe(handler)
-	unitUnderTest.honoMessageHandler(nil, mockMqttMessage)
+	unitUnderTest.honoMessageHandler(nil, mockMQTTMessage)
 
 	internal.AssertWithTimeout(t, &wg, 5)
 }
@@ -58,46 +58,46 @@ func TestHonoInvalidMesssageHandling(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	mockMqttMessage := mock.NewMockMessage(mockCtrl)
+	mockMQTTMessage := mock.NewMockMessage(mockCtrl)
 
 	unitUnderTest := NewClient(&Configuration{})
-	invalidJson := []byte("{\"t\"}")
+	invalidJSON := []byte("{\"t\"}")
 
 	handler := func(requestID string, message *protocol.Envelope) {
 		t.Errorf("handler should not be called")
 		t.Fail()
 	}
 
-	mockMqttMessage.EXPECT().Payload().Return(invalidJson)
+	mockMQTTMessage.EXPECT().Payload().Return(invalidJSON)
 
 	unitUnderTest.Subscribe(handler)
-	unitUnderTest.honoMessageHandler(nil, mockMqttMessage)
+	unitUnderTest.honoMessageHandler(nil, mockMQTTMessage)
 }
 
 func TestHonoWithoutHandlersDoesNotPanic(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	mockMqttMessage := mock.NewMockMessage(mockCtrl)
+	mockMQTTMessage := mock.NewMockMessage(mockCtrl)
 
 	unitUnderTest := NewClient(&Configuration{})
 
-	unitUnderTest.honoMessageHandler(nil, mockMqttMessage)
+	unitUnderTest.honoMessageHandler(nil, mockMQTTMessage)
 }
 
 func TestHonoMultipleHanlders(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	mockMqttMessage := mock.NewMockMessage(mockCtrl)
+	mockMQTTMessage := mock.NewMockMessage(mockCtrl)
 
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 
 	unitUnderTest := NewClient(&Configuration{})
 	validMessage := []byte("{\"test\": 15}")
-	requestId := "expected"
-	topic := createTopic(requestId)
+	requestID := "expected"
+	topic := createTopic(requestID)
 
 	expectedEnvelope, _ := getEnvelope(validMessage)
 
@@ -111,13 +111,13 @@ func TestHonoMultipleHanlders(t *testing.T) {
 		wg.Done()
 	}
 
-	mockMqttMessage.EXPECT().Payload().Return(validMessage)
-	mockMqttMessage.EXPECT().Topic().Return(topic)
+	mockMQTTMessage.EXPECT().Payload().Return(validMessage)
+	mockMQTTMessage.EXPECT().Topic().Return(topic)
 
 	unitUnderTest.Subscribe(handlerOne)
 	unitUnderTest.Subscribe(handlerTwo)
 
-	unitUnderTest.honoMessageHandler(nil, mockMqttMessage)
+	unitUnderTest.honoMessageHandler(nil, mockMQTTMessage)
 
 	internal.AssertWithTimeout(t, &wg, 5)
 }
@@ -126,7 +126,7 @@ func TestHonoAddMultipleHanlders(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	mockMqttMessage := mock.NewMockMessage(mockCtrl)
+	mockMQTTMessage := mock.NewMockMessage(mockCtrl)
 
 	wg := sync.WaitGroup{}
 	wg.Add(2)
@@ -134,8 +134,8 @@ func TestHonoAddMultipleHanlders(t *testing.T) {
 	unitUnderTest := NewClient(&Configuration{})
 
 	validMessage := []byte("{\"test\": 15}")
-	requestId := "expected"
-	topic := createTopic(requestId)
+	requestID := "expected"
+	topic := createTopic(requestID)
 
 	expectedEnvelope, _ := getEnvelope(validMessage)
 
@@ -149,12 +149,12 @@ func TestHonoAddMultipleHanlders(t *testing.T) {
 		wg.Done()
 	}
 
-	mockMqttMessage.EXPECT().Payload().Return(validMessage)
-	mockMqttMessage.EXPECT().Topic().Return(topic)
+	mockMQTTMessage.EXPECT().Payload().Return(validMessage)
+	mockMQTTMessage.EXPECT().Topic().Return(topic)
 
 	unitUnderTest.Subscribe(handlerOne, handlerTwo)
 
-	unitUnderTest.honoMessageHandler(nil, mockMqttMessage)
+	unitUnderTest.honoMessageHandler(nil, mockMQTTMessage)
 
 	internal.AssertWithTimeout(t, &wg, 5)
 }
@@ -163,7 +163,7 @@ func TestRemoveAllHanlders(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	mockMqttMessage := mock.NewMockMessage(mockCtrl)
+	mockMQTTMessage := mock.NewMockMessage(mockCtrl)
 
 	unitUnderTest := NewClient(&Configuration{})
 
@@ -177,15 +177,15 @@ func TestRemoveAllHanlders(t *testing.T) {
 		t.Fail()
 	}
 
-	mockMqttMessage.EXPECT().Payload().Times(0)
-	mockMqttMessage.EXPECT().Topic().Times(0)
+	mockMQTTMessage.EXPECT().Payload().Times(0)
+	mockMQTTMessage.EXPECT().Topic().Times(0)
 
 	// We already know this works from another test
 	unitUnderTest.Subscribe(handlerOne, handlerTwo)
 
 	unitUnderTest.Unsubscribe()
 
-	unitUnderTest.honoMessageHandler(nil, mockMqttMessage)
+	unitUnderTest.honoMessageHandler(nil, mockMQTTMessage)
 
 }
 
@@ -193,7 +193,7 @@ func TestRemoveSingleHanlder(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	mockMqttMessage := mock.NewMockMessage(mockCtrl)
+	mockMQTTMessage := mock.NewMockMessage(mockCtrl)
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
@@ -201,8 +201,8 @@ func TestRemoveSingleHanlder(t *testing.T) {
 	unitUnderTest := NewClient(&Configuration{})
 
 	validMessage := []byte("{\"test\": 15}")
-	requestId := "expected"
-	topic := createTopic(requestId)
+	requestID := "expected"
+	topic := createTopic(requestID)
 	expectedEnvelope, _ := getEnvelope(validMessage)
 
 	handlerOne := func(requestID string, message *protocol.Envelope) {
@@ -215,14 +215,14 @@ func TestRemoveSingleHanlder(t *testing.T) {
 		t.Fail()
 	}
 
-	mockMqttMessage.EXPECT().Payload().Return(validMessage)
-	mockMqttMessage.EXPECT().Topic().Return(topic)
+	mockMQTTMessage.EXPECT().Payload().Return(validMessage)
+	mockMQTTMessage.EXPECT().Topic().Return(topic)
 
 	unitUnderTest.Subscribe(handlerOne, handlerTwo)
 
 	unitUnderTest.Unsubscribe(handlerTwo)
 
-	unitUnderTest.honoMessageHandler(nil, mockMqttMessage)
+	unitUnderTest.honoMessageHandler(nil, mockMQTTMessage)
 	internal.AssertWithTimeout(t, &wg, 5)
 }
 
@@ -234,6 +234,6 @@ func TestGetHandlerName(t *testing.T) {
 	internal.AssertEqual(t, expectedName, actualName)
 }
 
-func createTopic(requestId string) string {
-	return fmt.Sprintf("command///req/%s/dosomething", requestId)
+func createTopic(requestID string) string {
+	return fmt.Sprintf("command///req/%s/dosomething", requestID)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -28,12 +28,12 @@ import (
 )
 
 var (
-	mockMqttClient *mock.MockClient
+	mockMQTTClient *mock.MockClient
 	mockToken      *mock.MockToken
 )
 
 func setup(controller *gomock.Controller) {
-	mockMqttClient = mock.NewMockClient(controller)
+	mockMQTTClient = mock.NewMockClient(controller)
 	mockToken = mock.NewMockToken(controller)
 }
 
@@ -50,9 +50,9 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
-type mockExecNewClientMqtt func(mockMqttClient *mock.MockClient, config *Configuration, message string) (*Client, error)
+type mockExecNewClientMQTT func(mockMQTTClient *mock.MockClient, config *Configuration, message string) (*Client, error)
 
-func TestNewClientMqtt(t *testing.T) {
+func TestNewClientMQTT(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -60,63 +60,63 @@ func TestNewClientMqtt(t *testing.T) {
 
 	tests := map[string]struct {
 		arg           *Configuration
-		mockExecution mockExecNewClientMqtt
+		mockExecution mockExecNewClientMQTT
 		errorMassage  string
 	}{
 		"test_connected_client": {
 			arg:           &Configuration{},
-			mockExecution: mockExecNewClientMqttNoErrors,
+			mockExecution: mockExecNewClientMQTTNoErrors,
 		},
 		"test_not_connected_client": {
 			arg:           &Configuration{},
-			mockExecution: mockExecNewClientMqttNotConnectedError,
+			mockExecution: mockExecNewClientMQTTNotConnectedError,
 			errorMassage:  "MQTT client is not connected",
 		},
 		"test_configuration_nil": {
 			arg:           nil,
-			mockExecution: mockExecNewClientMqttNoErrors,
+			mockExecution: mockExecNewClientMQTTNoErrors,
 		},
 		"test_configuration_broker_error": {
 			arg: &Configuration{
 				broker: "nil",
 			},
-			mockExecution: mockExecNewClientMqttConfigurationError,
+			mockExecution: mockExecNewClientMQTTConfigurationError,
 			errorMassage:  "broker is not expected when using external MQTT client",
 		},
 		"test_configuration_credentials_error": {
 			arg: &Configuration{
 				credentials: &Credentials{},
 			},
-			mockExecution: mockExecNewClientMqttConfigurationError,
+			mockExecution: mockExecNewClientMQTTConfigurationError,
 			errorMassage:  "credentials are not expected when using external MQTT client",
 		},
 		"test_configuration_disconnect_timeout_error": {
 			arg: &Configuration{
 				disconnectTimeout: 50,
 			},
-			mockExecution: mockExecNewClientMqttConfigurationError,
+			mockExecution: mockExecNewClientMQTTConfigurationError,
 			errorMassage:  "disconnectTimeout is not expected when using external MQTT client",
 		},
 		"test_configuration_keep_alive_error": {
 			arg: &Configuration{
 				keepAlive: 50,
 			},
-			mockExecution: mockExecNewClientMqttConfigurationError,
+			mockExecution: mockExecNewClientMQTTConfigurationError,
 			errorMassage:  "keepAlive is not expected when using external MQTT client",
 		},
 		"test_configuration_TLS_configuration_error": {
 			arg: &Configuration{
 				tlsConfig: &tls.Config{},
 			},
-			mockExecution: mockExecNewClientMqttConfigurationError,
+			mockExecution: mockExecNewClientMQTTConfigurationError,
 			errorMassage:  "TLS configuration is not expected when using external MQTT client",
 		},
 	}
 
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
-			expectedClient, expectedError := testCase.mockExecution(mockMqttClient, testCase.arg, testCase.errorMassage)
-			actualClient, actualError := NewClientMqtt(mockMqttClient, testCase.arg)
+			expectedClient, expectedError := testCase.mockExecution(mockMQTTClient, testCase.arg, testCase.errorMassage)
+			actualClient, actualError := NewClientMQTT(mockMQTTClient, testCase.arg)
 
 			internal.AssertEqual(t, expectedClient, actualClient)
 			internal.AssertError(t, expectedError, actualError)
@@ -145,15 +145,15 @@ func TestConnect(t *testing.T) {
 						testWg.Done()
 					},
 				},
-				pahoClient:         mockMqttClient,
-				externalMqttClient: true,
+				pahoClient:         mockMQTTClient,
+				externalMQTTClient: true,
 			},
 			mockExec: mockExecConnectNoError,
 		},
 		"test_external_mqtt_client_error": {
 			client: &Client{
-				pahoClient:         mockMqttClient,
-				externalMqttClient: true,
+				pahoClient:         mockMQTTClient,
+				externalMQTTClient: true,
 			},
 			mockExec: mockExecConnectError,
 		},
@@ -179,13 +179,13 @@ func TestDisconnectInternalClient(t *testing.T) {
 		cfg: &Configuration{
 			disconnectTimeout: defaultDisconnectTimeout,
 		},
-		pahoClient:         mockMqttClient,
-		externalMqttClient: false,
+		pahoClient:         mockMQTTClient,
+		externalMQTTClient: false,
 	}
 
-	mockMqttClient.EXPECT().Unsubscribe(honoMQTTTopicSubscribeCommands).Return(mockToken)
+	mockMQTTClient.EXPECT().Unsubscribe(honoMQTTTopicSubscribeCommands).Return(mockToken)
 	mockToken.EXPECT().Wait().Return(false)
-	mockMqttClient.EXPECT().Disconnect(uint(client.cfg.disconnectTimeout.Milliseconds())).Times(1)
+	mockMQTTClient.EXPECT().Disconnect(uint(client.cfg.disconnectTimeout.Milliseconds())).Times(1)
 
 	client.Disconnect()
 }
@@ -212,8 +212,8 @@ func TestDisconnectExternalClient(t *testing.T) {
 						testWg.Done()
 					},
 				},
-				pahoClient:         mockMqttClient,
-				externalMqttClient: true,
+				pahoClient:         mockMQTTClient,
+				externalMQTTClient: true,
 			},
 			err:      MQTT.ErrNotConnected,
 			mockExec: mockExecUnsubscribeError,
@@ -225,8 +225,8 @@ func TestDisconnectExternalClient(t *testing.T) {
 						testWg.Done()
 					},
 				},
-				pahoClient:         mockMqttClient,
-				externalMqttClient: true,
+				pahoClient:         mockMQTTClient,
+				externalMQTTClient: true,
 			},
 			mockExec: mockExecUnsubscribeNoError,
 		},
@@ -251,7 +251,7 @@ func TestReply(t *testing.T) {
 	setup(mockCtrl)
 
 	client := &Client{
-		pahoClient: mockMqttClient,
+		pahoClient: mockMQTTClient,
 	}
 
 	tests := map[string]struct {
@@ -289,7 +289,7 @@ func TestSend(t *testing.T) {
 	setup(mockCtrl)
 
 	client := &Client{
-		pahoClient: mockMqttClient,
+		pahoClient: mockMQTTClient,
 	}
 
 	tests := map[string]struct {
@@ -446,32 +446,32 @@ func TestUnsubscribe(t *testing.T) {
 }
 
 // Mock executions -------------------------------------------------------------
-// NewClientMqtt -------------------------------------------------------------
-func mockExecNewClientMqttNoErrors(mockMqttClient *mock.MockClient, config *Configuration, _ string) (*Client, error) {
-	mockMqttClient.EXPECT().IsConnected().Return(true)
+// NewClientMQTT -------------------------------------------------------------
+func mockExecNewClientMQTTNoErrors(mockMQTTClient *mock.MockClient, config *Configuration, _ string) (*Client, error) {
+	mockMQTTClient.EXPECT().IsConnected().Return(true)
 	return &Client{
 		cfg:                config,
-		pahoClient:         mockMqttClient,
-		externalMqttClient: true,
+		pahoClient:         mockMQTTClient,
+		externalMQTTClient: true,
 	}, nil
 }
 
-func mockExecNewClientMqttNotConnectedError(mockMqttClient *mock.MockClient, config *Configuration, message string) (*Client, error) {
-	mockMqttClient.EXPECT().IsConnected().Return(false)
+func mockExecNewClientMQTTNotConnectedError(mockMQTTClient *mock.MockClient, config *Configuration, message string) (*Client, error) {
+	mockMQTTClient.EXPECT().IsConnected().Return(false)
 	err := errors.New(message)
 	return nil, err
 }
 
-func mockExecNewClientMqttConfigurationError(mockMqttClient *mock.MockClient, config *Configuration, message string) (*Client, error) {
-	mockMqttClient.EXPECT().IsConnected().Return(true)
+func mockExecNewClientMQTTConfigurationError(mockMQTTClient *mock.MockClient, config *Configuration, message string) (*Client, error) {
+	mockMQTTClient.EXPECT().IsConnected().Return(true)
 	err := errors.New(message)
 	return nil, err
 }
 
-// MqttClientPublish -------------------------------------------------------------
+// MQTTClientPublish -------------------------------------------------------------
 func mockExecPublishNoErrors(topic string, payload interface{}) error {
 	mockToken.EXPECT().Wait().Return(false)
-	mockMqttClient.EXPECT().Publish(topic, byte(1), false, payload).Return(mockToken)
+	mockMQTTClient.EXPECT().Publish(topic, byte(1), false, payload).Return(mockToken)
 	return nil
 }
 
@@ -479,34 +479,34 @@ func mockExecPublishErrors(topic string, payload interface{}) error {
 	err := MQTT.ErrNotConnected
 	mockToken.EXPECT().Wait().Return(true)
 	mockToken.EXPECT().Error().AnyTimes().Return(err)
-	mockMqttClient.EXPECT().Publish(topic, byte(1), false, payload).Return(mockToken)
+	mockMQTTClient.EXPECT().Publish(topic, byte(1), false, payload).Return(mockToken)
 	return err
 }
 
-// MqttClientDisconnect -------------------------------------------------------------
+// MQTTClientDisconnect -------------------------------------------------------------
 func mockExecUnsubscribeNoError(client *Client, _ error) {
-	mockMqttClient.EXPECT().Unsubscribe(honoMQTTTopicSubscribeCommands).Return(mockToken)
+	mockMQTTClient.EXPECT().Unsubscribe(honoMQTTTopicSubscribeCommands).Return(mockToken)
 	mockToken.EXPECT().Wait().Return(false)
-	mockMqttClient.EXPECT().Disconnect(uint(client.cfg.disconnectTimeout.Milliseconds())).Times(0)
+	mockMQTTClient.EXPECT().Disconnect(uint(client.cfg.disconnectTimeout.Milliseconds())).Times(0)
 }
 
 func mockExecUnsubscribeError(client *Client, err error) {
-	mockMqttClient.EXPECT().Unsubscribe(honoMQTTTopicSubscribeCommands).Return(mockToken)
+	mockMQTTClient.EXPECT().Unsubscribe(honoMQTTTopicSubscribeCommands).Return(mockToken)
 	mockToken.EXPECT().Wait().Return(true)
 	mockToken.EXPECT().Error().AnyTimes().Return(err)
 }
 
-// MqttClientConnect -------------------------------------------------------------
+// MQTTClientConnect -------------------------------------------------------------
 func mockExecConnectNoError(testWg *sync.WaitGroup) error {
 	testWg.Add(1)
 	var qos byte = 1
-	mockMqttClient.EXPECT().Subscribe(honoMQTTTopicSubscribeCommands, qos, gomock.Any()).Return(mockToken)
+	mockMQTTClient.EXPECT().Subscribe(honoMQTTTopicSubscribeCommands, qos, gomock.Any()).Return(mockToken)
 	mockToken.EXPECT().Wait().Return(false)
 	return nil
 }
 
 func mockExecConnectError(testWg *sync.WaitGroup) error {
-	mockMqttClient.EXPECT().Subscribe(honoMQTTTopicSubscribeCommands, byte(1), gomock.Any()).Return(mockToken)
+	mockMQTTClient.EXPECT().Subscribe(honoMQTTTopicSubscribeCommands, byte(1), gomock.Any()).Return(mockToken)
 	mockToken.EXPECT().Wait().Return(true)
 	mockToken.EXPECT().Error().AnyTimes().Return(MQTT.ErrNotConnected)
 	return MQTT.ErrNotConnected

--- a/model/definition_id.go
+++ b/model/definition_id.go
@@ -55,15 +55,15 @@ func NewDefinitionID(namespace string, name string, version string) *DefinitionI
 }
 
 // String provides the string representation of a DefinitionID in the Ditto's specified form of 'namespace:name:version'.
-func (definitionId *DefinitionID) String() string {
-	return fmt.Sprintf(definitionIDTemplate, definitionId.Namespace, definitionId.Name, definitionId.Version)
+func (definitionID *DefinitionID) String() string {
+	return fmt.Sprintf(definitionIDTemplate, definitionID.Namespace, definitionID.Name, definitionID.Version)
 }
 
-func (definitionId *DefinitionID) MarshalJSON() ([]byte, error) {
-	return json.Marshal(definitionId.String())
+func (definitionID *DefinitionID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(definitionID.String())
 }
 
-func (definitionId *DefinitionID) UnmarshalJSON(data []byte) error {
+func (definitionID *DefinitionID) UnmarshalJSON(data []byte) error {
 	var defIDString = ""
 
 	if err := json.Unmarshal(data, &defIDString); err != nil {
@@ -75,28 +75,28 @@ func (definitionId *DefinitionID) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	definitionId.Namespace = matches[1]
-	definitionId.Name = matches[2]
-	definitionId.Version = matches[3]
+	definitionID.Namespace = matches[1]
+	definitionID.Name = matches[2]
+	definitionID.Version = matches[3]
 	return nil
 }
 
 // WithNamespace sets the provided namespace to the current DefinitionID instance.
-func (definitionId *DefinitionID) WithNamespace(namespace string) *DefinitionID {
-	definitionId.Namespace = namespace
-	return definitionId
+func (definitionID *DefinitionID) WithNamespace(namespace string) *DefinitionID {
+	definitionID.Namespace = namespace
+	return definitionID
 }
 
 // WithName sets the provided name to the current DefinitionID instance.
-func (definitionId *DefinitionID) WithName(name string) *DefinitionID {
-	definitionId.Name = name
-	return definitionId
+func (definitionID *DefinitionID) WithName(name string) *DefinitionID {
+	definitionID.Name = name
+	return definitionID
 }
 
 // WithVersion sets the provided version to the current DefinitionID instance.
-func (definitionId *DefinitionID) WithVersion(version string) *DefinitionID {
-	definitionId.Version = version
-	return definitionId
+func (definitionID *DefinitionID) WithVersion(version string) *DefinitionID {
+	definitionID.Version = version
+	return definitionID
 }
 
 func validateDefinitionID(defIDString string) ([]string, error) {

--- a/model/thing.go
+++ b/model/thing.go
@@ -36,14 +36,14 @@ func (thing *Thing) WithIDFrom(id string) *Thing {
 }
 
 // WithDefinition sets the current Thing instance's definition to the provided value.
-func (thing *Thing) WithDefinition(definition *DefinitionID) *Thing {
-	thing.DefinitionID = definition
+func (thing *Thing) WithDefinition(definitionID *DefinitionID) *Thing {
+	thing.DefinitionID = definitionID
 	return thing
 }
 
 // WithDefinitionFrom is an auxiliary method to set the current Thing instance's definition to the provided one in the form of 'namespace:name:version'.
-func (thing *Thing) WithDefinitionFrom(definitionId string) *Thing {
-	thing.DefinitionID = NewDefinitionIDFrom(definitionId)
+func (thing *Thing) WithDefinitionFrom(definitionID string) *Thing {
+	thing.DefinitionID = NewDefinitionIDFrom(definitionID)
 	return thing
 }
 
@@ -55,8 +55,8 @@ func (thing *Thing) WithPolicyID(policyID *NamespacedID) *Thing {
 
 // WithPolicyIDFrom is an auxiliary method that sets the Policy ID of the current Thing instance
 // from a string NamespacedID representation in the form of 'namespace:name'.
-func (thing *Thing) WithPolicyIDFrom(policyId string) *Thing {
-	thing.PolicyID = NewNamespacedIDFrom(policyId)
+func (thing *Thing) WithPolicyIDFrom(policyID string) *Thing {
+	thing.PolicyID = NewNamespacedIDFrom(policyID)
 	return thing
 }
 

--- a/protocol/envelope_test.go
+++ b/protocol/envelope_test.go
@@ -19,12 +19,12 @@ import (
 func TestEnvelopeWithTopic(t *testing.T) {
 	t.Run("TestEnvelopeWithTopic", func(t *testing.T) {
 		arg := &Topic{
-			Namespace: "anamespace",
-			EntityID:  "aentityid",
-			Group:     GroupThings,
-			Channel:   ChannelTwin,
-			Criterion: CriterionMessages,
-			Action:    ActionSubscribe,
+			Namespace:  "namespace",
+			EntityName: "entity_name",
+			Group:      GroupThings,
+			Channel:    ChannelTwin,
+			Criterion:  CriterionMessages,
+			Action:     ActionSubscribe,
 		}
 		msg := &Envelope{}
 		if got := msg.WithTopic(arg); !reflect.DeepEqual(got.Topic, arg) {

--- a/protocol/headers_opts.go
+++ b/protocol/headers_opts.go
@@ -34,9 +34,9 @@ func NewHeaders(opts ...HeaderOpt) *Headers {
 	return res
 }
 
-func WithCorrelationID(correlationId string) HeaderOpt {
+func WithCorrelationID(correlationID string) HeaderOpt {
 	return func(headers *Headers) error {
-		headers.Values[HeaderCorrelationID] = correlationId
+		headers.Values[HeaderCorrelationID] = correlationID
 		return nil
 	}
 }

--- a/protocol/things/commands.go
+++ b/protocol/things/commands.go
@@ -55,7 +55,7 @@ func NewCommand(thingID *model.NamespacedID) *Command {
 	return &Command{
 		Topic: (&protocol.Topic{}).
 			WithNamespace(thingID.Namespace).
-			WithEntityID(thingID.Name).
+			WithEntityName(thingID.Name).
 			WithGroup(protocol.GroupThings).
 			WithChannel(protocol.ChannelTwin).
 			WithCriterion(protocol.CriterionCommands),

--- a/protocol/things/commands_test.go
+++ b/protocol/things/commands_test.go
@@ -34,11 +34,11 @@ var (
 func TestNewCommand(t *testing.T) {
 	want := &Command{
 		Topic: &protocol.Topic{
-			Namespace: testNamespaceID.Namespace,
-			EntityID:  testNamespaceID.Name,
-			Group:     protocol.GroupThings,
-			Channel:   protocol.ChannelTwin,
-			Criterion: protocol.CriterionCommands,
+			Namespace:  testNamespaceID.Namespace,
+			EntityName: testNamespaceID.Name,
+			Group:      protocol.GroupThings,
+			Channel:    protocol.ChannelTwin,
+			Criterion:  protocol.CriterionCommands,
 		},
 		Path: pathThing,
 	}

--- a/protocol/things/events.go
+++ b/protocol/things/events.go
@@ -40,7 +40,7 @@ func NewEvent(thingID *model.NamespacedID) *Event {
 	return &Event{
 		Topic: (&protocol.Topic{}).
 			WithNamespace(thingID.Namespace).
-			WithEntityID(thingID.Name).
+			WithEntityName(thingID.Name).
 			WithGroup(protocol.GroupThings).
 			WithChannel(protocol.ChannelTwin).
 			WithCriterion(protocol.CriterionEvents),

--- a/protocol/things/events_test.go
+++ b/protocol/things/events_test.go
@@ -22,11 +22,11 @@ import (
 func TestNewEvent(t *testing.T) {
 	want := &Event{
 		Topic: &protocol.Topic{
-			Namespace: testNamespaceID.Namespace,
-			EntityID:  testNamespaceID.Name,
-			Group:     protocol.GroupThings,
-			Channel:   protocol.ChannelTwin,
-			Criterion: protocol.CriterionEvents,
+			Namespace:  testNamespaceID.Namespace,
+			EntityName: testNamespaceID.Name,
+			Group:      protocol.GroupThings,
+			Channel:    protocol.ChannelTwin,
+			Criterion:  protocol.CriterionEvents,
 		},
 		Path: pathThing,
 	}

--- a/protocol/things/messages.go
+++ b/protocol/things/messages.go
@@ -43,7 +43,7 @@ func NewMessage(thingID *model.NamespacedID) *Message {
 	return &Message{
 		Topic: (&protocol.Topic{}).
 			WithNamespace(thingID.Namespace).
-			WithEntityID(thingID.Name).
+			WithEntityName(thingID.Name).
 			WithGroup(protocol.GroupThings).
 			WithChannel(protocol.ChannelLive).
 			WithCriterion(protocol.CriterionMessages),

--- a/protocol/things/messages_test.go
+++ b/protocol/things/messages_test.go
@@ -22,11 +22,11 @@ import (
 func TestNewMessage(t *testing.T) {
 	want := &Message{
 		Topic: &protocol.Topic{
-			Namespace: testNamespaceID.Namespace,
-			EntityID:  testNamespaceID.Name,
-			Group:     protocol.GroupThings,
-			Channel:   protocol.ChannelLive,
-			Criterion: protocol.CriterionMessages,
+			Namespace:  testNamespaceID.Namespace,
+			EntityName: testNamespaceID.Name,
+			Group:      protocol.GroupThings,
+			Channel:    protocol.ChannelLive,
+			Criterion:  protocol.CriterionMessages,
 		},
 		AddressedPartOfThing: "",
 	}

--- a/protocol/topic.go
+++ b/protocol/topic.go
@@ -80,15 +80,15 @@ var regexFiveElementTopic = regexp.MustCompile("^([^/]+)/([^/]+)/([^/]+)/([^/]+)
 var regexSixElementTopic = regexp.MustCompile("^([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/]+)$")
 
 // Topic represents the Ditto protocol's Topic entity. It's represented in the form of:
-// <namespace>/<entityID>/<group>/<channel>/<criterion>/<action>.
+// <namespace>/<entity-name>/<group>/<channel>/<criterion>/<action>.
 // Each of the components is configurable based on the Ditto's specification for the specific group and/or channel/criterion/etc.
 type Topic struct {
-	Namespace string
-	EntityID  string
-	Group     TopicGroup
-	Channel   TopicChannel
-	Criterion TopicCriterion
-	Action    TopicAction
+	Namespace  string
+	EntityName string
+	Group      TopicGroup
+	Channel    TopicChannel
+	Criterion  TopicCriterion
+	Action     TopicAction
 }
 
 // String provides the string representation of a Topic entity.
@@ -96,11 +96,11 @@ func (topic *Topic) String() string {
 	switch topic.Group {
 	case GroupThings:
 		if len(topic.Action) == 0 {
-			return fmt.Sprintf(topicFormatThingsNoAction, topic.Namespace, topic.EntityID, topic.Group, topic.Channel, topic.Criterion)
+			return fmt.Sprintf(topicFormatThingsNoAction, topic.Namespace, topic.EntityName, topic.Group, topic.Channel, topic.Criterion)
 		}
-		return fmt.Sprintf(topicFormatThings, topic.Namespace, topic.EntityID, topic.Group, topic.Channel, topic.Criterion, topic.Action)
+		return fmt.Sprintf(topicFormatThings, topic.Namespace, topic.EntityName, topic.Group, topic.Channel, topic.Criterion, topic.Action)
 	case GroupPolicies:
-		return fmt.Sprintf(topicFormatPolicies, topic.Namespace, topic.EntityID, topic.Group, topic.Criterion, topic.Action)
+		return fmt.Sprintf(topicFormatPolicies, topic.Namespace, topic.EntityName, topic.Group, topic.Criterion, topic.Action)
 	default:
 		return ""
 	}
@@ -122,7 +122,7 @@ func (topic *Topic) UnmarshalJSON(data []byte) error {
 	index := 0
 	topic.Namespace = elements[index]
 	index++
-	topic.EntityID = elements[index]
+	topic.EntityName = elements[index]
 	index++
 	topic.Group = TopicGroup(elements[index])
 	index++
@@ -152,9 +152,9 @@ func (topic *Topic) WithNamespace(ns string) *Topic {
 	return topic
 }
 
-// WithEntityID configures the entity ID of the Topic.
-func (topic *Topic) WithEntityID(entityID string) *Topic {
-	topic.EntityID = entityID
+// WithEntityName configures the entity name of the Topic.
+func (topic *Topic) WithEntityName(entityName string) *Topic {
+	topic.EntityName = entityName
 	return topic
 }
 

--- a/protocol/topic_test.go
+++ b/protocol/topic_test.go
@@ -25,38 +25,38 @@ func TestTopicString(t *testing.T) {
 		{
 			name: "TestTopicString GroupThings",
 			topic: Topic{
-				Namespace: "anamespace",
-				EntityID:  "aentityid",
-				Group:     GroupThings,
-				Channel:   ChannelTwin,
-				Criterion: CriterionMessages,
-				Action:    ActionSubscribe,
+				Namespace:  "namespace",
+				EntityName: "entity_name",
+				Group:      GroupThings,
+				Channel:    ChannelTwin,
+				Criterion:  CriterionMessages,
+				Action:     ActionSubscribe,
 			},
-			want: "anamespace/aentityid/" + string(GroupThings) + "/" + string(ChannelTwin) + "/" +
+			want: "namespace/entity_name/" + string(GroupThings) + "/" + string(ChannelTwin) + "/" +
 				string(CriterionMessages) + "/" + string(ActionSubscribe),
 		},
 		{
 			name: "TestTopicString GroupPolicies",
 			topic: Topic{
-				Namespace: "anamespace",
-				EntityID:  "aentityid",
-				Group:     GroupPolicies,
-				Channel:   "",
-				Criterion: CriterionCommands,
-				Action:    ActionCreate,
+				Namespace:  "namespace",
+				EntityName: "entity_name",
+				Group:      GroupPolicies,
+				Channel:    "",
+				Criterion:  CriterionCommands,
+				Action:     ActionCreate,
 			},
-			want: "anamespace/aentityid/" + string(GroupPolicies) + "/" +
+			want: "namespace/entity_name/" + string(GroupPolicies) + "/" +
 				string(CriterionCommands) + "/" + string(ActionCreate),
 		},
 		{
 			name: "TestTopicString empty",
 			topic: Topic{
-				Namespace: "anamespace",
-				EntityID:  "aentityid",
-				Group:     "",
-				Channel:   "",
-				Criterion: CriterionCommands,
-				Action:    ActionCreate,
+				Namespace:  "namespace",
+				EntityName: "entity_name",
+				Group:      "",
+				Channel:    "",
+				Criterion:  CriterionCommands,
+				Action:     ActionCreate,
 			},
 			want: "",
 		}}
@@ -74,15 +74,15 @@ func TestTopicString(t *testing.T) {
 func TestTopicMarshalJSON(t *testing.T) {
 	t.Run("TestTopicMarshalJSON", func(t *testing.T) {
 		topic := Topic{
-			Namespace: "namespace",
-			EntityID:  "entityid",
-			Group:     GroupThings,
-			Channel:   ChannelTwin,
-			Criterion: CriterionMessages,
-			Action:    ActionSubscribe,
+			Namespace:  "namespace",
+			EntityName: "entity_name",
+			Group:      GroupThings,
+			Channel:    ChannelTwin,
+			Criterion:  CriterionMessages,
+			Action:     ActionSubscribe,
 		}
 		got, err := topic.MarshalJSON()
-		grp := "\"namespace/entityid/" + string(GroupThings) +
+		grp := "\"namespace/entity_name/" + string(GroupThings) +
 			"/" + string(ChannelTwin) + "/" + string(CriterionMessages) + "/" +
 			string(ActionSubscribe) + "\""
 		if err != nil {
@@ -104,7 +104,7 @@ func TestTopicUnmarshalJSON(t *testing.T) {
 	}{
 		{
 			name: "TestTopicUnmarshalJSON GroupThings",
-			data: "anamespace/aentityid/" +
+			data: "namespace/entity_name/" +
 				string(GroupThings) + "/" + string(ChannelTwin) + "/" + string(CriterionMessages) + "/" +
 				string(ActionSubscribe),
 			wantErr:               false,
@@ -112,7 +112,7 @@ func TestTopicUnmarshalJSON(t *testing.T) {
 		},
 		{
 			name: "TestTopicUnmarshalJSON GroupPolicies",
-			data: "anamespace/aentityid/" +
+			data: "namespace/entity_name/" +
 				string(GroupPolicies) + "/" + string(CriterionCommands) + "/" + string(ActionCreate),
 			wantErr:               false,
 			onlyForUnmarshalError: false,
@@ -125,7 +125,7 @@ func TestTopicUnmarshalJSON(t *testing.T) {
 		},
 		{
 			name: "TestTopicUnmarshalJSON GroupThings for missing channel for things",
-			data: "anamespace/aentityid/" +
+			data: "namespace/entity_name/" +
 				string(GroupThings) + "/" /*+ string(ChannelTwin) + "/"*/ + string(CriterionMessages) + "/" +
 				string(ActionSubscribe),
 			wantErr:               true,
@@ -133,7 +133,7 @@ func TestTopicUnmarshalJSON(t *testing.T) {
 		},
 		{
 			name: "TestTopicUnmarshalJSON GroupThings insufficient elements for things",
-			data: "anamespace/aentityid/" +
+			data: "namespace/entity_name/" +
 				string(GroupThings) + "/" + string(ChannelTwin) + "/" + string(CriterionMessages),
 			wantErr:               true,
 			onlyForUnmarshalError: false,
@@ -152,13 +152,12 @@ func TestTopicUnmarshalJSON(t *testing.T) {
 		},
 		{
 			name: "TestTopicUnmarshalJSON only for internal error",
-			data: "anamespace/aentityid/" +
+			data: "namespace/entity_name/" +
 				string(GroupThings) + "/" + string(ChannelTwin) + "/" + string(CriterionMessages) + "/" +
 				string(ActionSubscribe),
 			wantErr:               true,
 			onlyForUnmarshalError: true,
 		},
-	
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -206,7 +205,7 @@ func TestTopicUnmarshalJSON(t *testing.T) {
 
 func TestTopicWithNamespace(t *testing.T) {
 	t.Run("TestTopicWithNamespace", func(t *testing.T) {
-		arg := "anamespace"
+		arg := "namespace"
 		topic := Topic{}
 		if got := topic.WithNamespace(arg); !reflect.DeepEqual(got.Namespace, arg) {
 			t.Errorf("Topic.WithNamespace() = %v, want %v", got.Namespace, arg)
@@ -214,12 +213,12 @@ func TestTopicWithNamespace(t *testing.T) {
 	})
 }
 
-func TestTopicWithEntityID(t *testing.T) {
-	t.Run("TestTopicWithEntityID", func(t *testing.T) {
-		arg := "EntityID"
+func TestTopicWithEntityName(t *testing.T) {
+	t.Run("TestTopicWithEntityName", func(t *testing.T) {
+		arg := "EntityName"
 		topic := Topic{}
-		if got := topic.WithEntityID(arg); !reflect.DeepEqual(got.EntityID, arg) {
-			t.Errorf("Topic.WithEntityID() = %v, want %v", got.EntityID, arg)
+		if got := topic.WithEntityName(arg); !reflect.DeepEqual(got.EntityName, arg) {
+			t.Errorf("Topic.WithEntityName() = %v, want %v", got.EntityName, arg)
 		}
 	})
 }

--- a/utils.go
+++ b/utils.go
@@ -27,10 +27,10 @@ const (
 	honoMQTTTopicCommandResponseFormat = "command///res/%s/%d"
 )
 
-func extractHonoRequestId(honoTopic string) string {
+func extractHonoRequestID(honoTopic string) string {
 	if regexHonoMQTTTopicRequest.MatchString(honoTopic) {
-		reqIdInfo := regexHonoMQTTTopicRequest.FindStringSubmatch(honoTopic)
-		return reqIdInfo[1]
+		reqIDInfo := regexHonoMQTTTopicRequest.FindStringSubmatch(honoTopic)
+		return reqIDInfo[1]
 	}
 	return ""
 }
@@ -40,7 +40,7 @@ func generateHonoResponseTopic(requestID string, status int) string {
 }
 
 func getEnvelope(mqttPayload []byte) (*protocol.Envelope, error) {
-	env := &protocol.Envelope{}
+	env := &protocol.Envelope{Headers: protocol.NewHeaders()}
 	if err := json.Unmarshal(mqttPayload, env); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixed ditto.NewClientMqtt to be ditto.NewClientMQTT.
Fixed nil pointer panic when getting a header value of messages without headers.test

Signed-off-by: Dimitar Dimitrov <dimitar.dimitrov3@bosch.io>