### PR TITLE
Missing Topic NamespacedID validation on Envelope unmarshalling

### DIFF
--- a/client_config_test.go
+++ b/client_config_test.go
@@ -16,6 +16,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/eclipse/ditto-clients-golang/internal"
 )
 
 func TestNewConfiguration(t *testing.T) {
@@ -24,9 +26,8 @@ func TestNewConfiguration(t *testing.T) {
 		disconnectTimeout: defaultDisconnectTimeout,
 	}
 
-	if got := NewConfiguration(); !reflect.DeepEqual(got, want) {
-		t.Errorf("NewConfiguration() = %v, want %v", got, want)
-	}
+	got := NewConfiguration()
+	internal.AssertEqual(t, want, got)
 }
 
 func TestBroker(t *testing.T) {
@@ -48,9 +49,8 @@ func TestBroker(t *testing.T) {
 
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
-			if got := testCase.testConfiguration.Broker(); got != testCase.want {
-				t.Errorf("Broker() = %v, want %v", got, testCase.want)
-			}
+			got := testCase.testConfiguration.Broker()
+			internal.AssertEqual(t, testCase.want, got)
 		})
 	}
 }
@@ -78,9 +78,8 @@ func TestKeepAlive(t *testing.T) {
 
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
-			if got := testCase.testConfiguration.KeepAlive(); got != testCase.want {
-				t.Errorf("KeepAlive() = %v, want %v", got, testCase.want)
-			}
+			got := testCase.testConfiguration.KeepAlive()
+			internal.AssertEqual(t, testCase.want, got)
 		})
 	}
 }
@@ -108,9 +107,8 @@ func TestDisconnectTimeout(t *testing.T) {
 
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
-			if got := testCase.testConfiguration.DisconnectTimeout(); got != testCase.want {
-				t.Errorf("DisconnectTimeout() = %v, want %v", got, testCase.want)
-			}
+			got := testCase.testConfiguration.DisconnectTimeout()
+			internal.AssertEqual(t, testCase.want, got)
 		})
 	}
 }
@@ -167,12 +165,7 @@ func TestCredentials(t *testing.T) {
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
 			got := testCase.testConfiguration.Credentials()
-			if got != testCase.want {
-				t.Error("Credentials objects are not the same")
-			}
-			if !reflect.DeepEqual(got, testCase.want) {
-				t.Errorf("Credentials() = %v, want %v", got, testCase.want)
-			}
+			internal.AssertEqual(t, testCase.want, got)
 		})
 	}
 }
@@ -266,12 +259,7 @@ func TestTLSConfig(t *testing.T) {
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
 			got := testCase.testConfiguration.TLSConfig()
-			if got != testCase.want {
-				t.Error("tls.Config objects are not the same")
-			}
-			if !reflect.DeepEqual(got, testCase.want) {
-				t.Errorf("TLSConfig() = %v, want %v", got, testCase.want)
-			}
+			internal.AssertEqual(t, testCase.want, got)
 		})
 	}
 }
@@ -285,9 +273,8 @@ func TestWithBroker(t *testing.T) {
 		broker: arg,
 	}
 
-	if got := testConfiguration.WithBroker(arg); !reflect.DeepEqual(got, want) {
-		t.Errorf("WithBroker() = %v, want %v", got, want)
-	}
+	got := testConfiguration.WithBroker(arg)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestWithKeepAlive(t *testing.T) {
@@ -299,9 +286,8 @@ func TestWithKeepAlive(t *testing.T) {
 		keepAlive: arg,
 	}
 
-	if got := testConfiguration.WithKeepAlive(arg); !reflect.DeepEqual(got, want) {
-		t.Errorf("WithKeepAlive() = %v, want %v", got, want)
-	}
+	got := testConfiguration.WithKeepAlive(arg)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestWithDisconnectTimeout(t *testing.T) {
@@ -313,9 +299,8 @@ func TestWithDisconnectTimeout(t *testing.T) {
 		disconnectTimeout: arg,
 	}
 
-	if got := testConfiguration.WithDisconnectTimeout(arg); !reflect.DeepEqual(got, want) {
-		t.Errorf("WithDisconnectTimeout() = %v, want %v", got, want)
-	}
+	got := testConfiguration.WithDisconnectTimeout(arg)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestWitWithCredentials(t *testing.T) {
@@ -330,9 +315,8 @@ func TestWitWithCredentials(t *testing.T) {
 		credentials: arg,
 	}
 
-	if got := testConfiguration.WithCredentials(arg); !reflect.DeepEqual(got, want) {
-		t.Errorf("WithCredentials() = %v, want %v", got, want)
-	}
+	got := testConfiguration.WithCredentials(arg)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestWithConnectHandler(t *testing.T) {
@@ -372,7 +356,6 @@ func TestWithTLSConfig(t *testing.T) {
 		tlsConfig: arg,
 	}
 
-	if got := testConfiguration.WithTLSConfig(arg); !reflect.DeepEqual(got, want) {
-		t.Errorf("WithTLSConfig() = %v, want %v", got, want)
-	}
+	got := testConfiguration.WithTLSConfig(arg)
+	internal.AssertEqual(t, want, got)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -45,9 +45,8 @@ func TestNewClient(t *testing.T) {
 		handlers: map[string]Handler{},
 	}
 
-	if got := NewClient(config); !reflect.DeepEqual(got, want) {
-		t.Errorf("NewClient()= %v, want %v", got, want)
-	}
+	got := NewClient(config)
+	internal.AssertEqual(t, want, got)
 }
 
 type mockExecNewClientMQTT func(mockMQTTClient *mock.MockClient, config *Configuration, message string) (*Client, error)
@@ -362,7 +361,7 @@ func TestSubscribe(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			testCase.testClient.Subscribe(testCase.arg...)
 			handlers := testCase.testClient.handlers
-			internal.AssertEqual(t, len(handlers), len(testCase.want))
+			internal.AssertEqual(t, len(testCase.want), len(handlers))
 			for key, element := range testCase.want {
 				got := handlers[key]
 				if got == nil || reflect.ValueOf(got).Pointer() != reflect.ValueOf(element).Pointer() {
@@ -433,10 +432,11 @@ func TestUnsubscribe(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			testCase.testClient.Unsubscribe(testCase.arg...)
 			handlers := testCase.testClient.handlers
-			internal.AssertEqual(t, len(handlers), len(testCase.want))
+			internal.AssertEqual(t, len(testCase.want), len(handlers))
 			for key, element := range testCase.want {
 				got := handlers[key]
-				if got == nil || reflect.ValueOf(got).Pointer() != reflect.ValueOf(element).Pointer() {
+				internal.AssertNotNil(t, got)
+				if reflect.ValueOf(got).Pointer() != reflect.ValueOf(element).Pointer() {
 					t.Errorf("Client.Unsubscribe()= %v, want %v", got, element)
 				}
 			}

--- a/internal/assertions.go
+++ b/internal/assertions.go
@@ -18,6 +18,7 @@ import (
 	"time"
 )
 
+// AssertError asserts that the expected and actual errors are the same.
 func AssertError(t *testing.T, expected error, actual error) {
 	if expected == nil {
 		if actual != nil {
@@ -37,6 +38,7 @@ func AssertError(t *testing.T, expected error, actual error) {
 	}
 }
 
+// AssertEqual asserts that the expected and actual values are deeply equal.
 func AssertEqual(t *testing.T, expected interface{}, actual interface{}) {
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("expected %v , got %v", expected, actual)
@@ -44,6 +46,17 @@ func AssertEqual(t *testing.T, expected interface{}, actual interface{}) {
 	}
 }
 
+// AssertTrue asserts that the actual value is true.
+func AssertTrue(t *testing.T, actual bool) {
+	AssertEqual(t, true, actual)
+}
+
+// AssertFalse asserts that the actual value is false.
+func AssertFalse(t *testing.T, actual bool) {
+	AssertEqual(t, false, actual)
+}
+
+// AssertWithTimeout asserts that an operation is completed within a certain period of time.
 func AssertWithTimeout(t *testing.T, waitGroup *sync.WaitGroup, testTimeout time.Duration) {
 	testWaitChan := make(chan struct{})
 	go func() {
@@ -56,4 +69,49 @@ func AssertWithTimeout(t *testing.T, waitGroup *sync.WaitGroup, testTimeout time
 	case <-time.After(testTimeout * time.Second):
 		t.Fatal("timed out waiting for ", testTimeout)
 	}
+}
+
+// AssertNil asserts that a value is nil.
+func AssertNil(t *testing.T, value interface{}) {
+	if !IsNil(value) {
+		t.Fatalf("expected nil, but was %+v", value)
+	}
+}
+
+// AssertNotNil asserts that a value is not nil.
+func AssertNotNil(t *testing.T, value interface{}) {
+	if IsNil(value) {
+		t.Fatalf("expected value not to be nil")
+	}
+}
+
+// IsNil checks if a value is nil.
+func IsNil(v interface{}) bool {
+	if v == nil {
+		return true
+	}
+	value := reflect.ValueOf(v)
+	kind := value.Kind()
+	isNilableKind := containsKind(
+		[]reflect.Kind{
+			reflect.Chan, reflect.Func,
+			reflect.Interface, reflect.Map,
+			reflect.Ptr, reflect.Slice},
+		kind)
+
+	if isNilableKind && value.IsNil() {
+		return true
+	}
+
+	return false
+}
+
+func containsKind(kinds []reflect.Kind, kind reflect.Kind) bool {
+	for i := 0; i < len(kinds); i++ {
+		if kind == kinds[i] {
+			return true
+		}
+	}
+
+	return false
 }

--- a/model/definition_id_test.go
+++ b/model/definition_id_test.go
@@ -25,19 +25,19 @@ func TestDefinitionIDNewDefinitionIDFrom(t *testing.T) {
 		want *DefinitionID
 	}{
 		"test_new_definition_id_from_valid": {
-			arg: "test.namespace_42:testId:1.0.0-qualifier",
+			arg: "test.namespace_42:test-name:1.0.0-qualifier",
 			want: &DefinitionID{
 				Namespace: "test.namespace_42",
-				Name:      "testId",
+				Name:      "test-name",
 				Version:   "1.0.0-qualifier",
 			},
 		},
 		"test_new_definition_id_from_without_namespace": {
-			arg:  ":testId:1.0.0",
+			arg:  ":test-name:1.0.0",
 			want: nil,
 		},
 		"test_new_definition_id_from_without_name": {
-			arg:  "testId:1.0.0",
+			arg:  "test-name:1.0.0",
 			want: nil,
 		},
 		"test_new_definition_id_from_without_version": {
@@ -45,11 +45,11 @@ func TestDefinitionIDNewDefinitionIDFrom(t *testing.T) {
 			want: nil,
 		},
 		"test_new_definition_id_from_with_invalid_colon": {
-			arg:  "test.namespace:testId:1.0.0:",
+			arg:  "test.namespace:test-name:1.0.0:",
 			want: nil,
 		},
 		"test_new_definition_id_from_with_invalid_character": {
-			arg:  "test.name*space:testId:1.0.0",
+			arg:  "test.name*space:test-name:1.0.0",
 			want: nil,
 		},
 		"test_new_definition_id_from_empty": {
@@ -57,18 +57,18 @@ func TestDefinitionIDNewDefinitionIDFrom(t *testing.T) {
 			want: nil,
 		},
 		"test_new_definition_id_from_namespace_with_dash": {
-			arg: "test-namespace:testId:1.0.0-qualifier",
+			arg: "test-namespace:test-name:1.0.0-qualifier",
 			want: &DefinitionID{
 				Namespace: "test-namespace",
-				Name:      "testId",
+				Name:      "test-name",
 				Version:   "1.0.0-qualifier",
 			},
 		},
 		"test_new_definition_id_from_namespace_with_dash_dot": {
-			arg: "test.namespace-id:testId:1.0.0-qualifier",
+			arg: "test.namespace-dash-dot:test-name:1.0.0-qualifier",
 			want: &DefinitionID{
-				Namespace: "test.namespace-id",
-				Name:      "testId",
+				Namespace: "test.namespace-dash-dot",
+				Name:      "test-name",
 				Version:   "1.0.0-qualifier",
 			},
 		},
@@ -77,7 +77,7 @@ func TestDefinitionIDNewDefinitionIDFrom(t *testing.T) {
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
 			got := NewDefinitionIDFrom(testCase.arg)
-			internal.AssertEqual(t, got, testCase.want)
+			internal.AssertEqual(t, testCase.want, got)
 		})
 	}
 }
@@ -88,30 +88,30 @@ func TestDefinitionIDNewDefinitionID(t *testing.T) {
 		want *DefinitionID
 	}{
 		"test_new_definition_id_valid": {
-			args: []string{"test.namespace_42", "testId", "1.0.0-qualifier"},
+			args: []string{"test.namespace_42", "test-name", "1.0.0-qualifier"},
 			want: &DefinitionID{
 				Namespace: "test.namespace_42",
-				Name:      "testId",
+				Name:      "test-name",
 				Version:   "1.0.0-qualifier",
 			},
 		},
 		"test_new_definition_id_invalid": {
-			args: []string{"test/namespace", "testId", "1.0.0"},
+			args: []string{"test/namespace", "test-name", "1.0.0"},
 			want: nil,
 		},
 		"test_new_definition_id_namespace_dash": {
-			args: []string{"test-namespace", "testId", "1.0.0-qualifier"},
+			args: []string{"test-namespace", "test-name", "1.0.0-qualifier"},
 			want: &DefinitionID{
 				Namespace: "test-namespace",
-				Name:      "testId",
+				Name:      "test-name",
 				Version:   "1.0.0-qualifier",
 			},
 		},
 		"test_new_definition_id_namespace_dash_dot": {
-			args: []string{"test.namespace-id", "testId", "1.0.0-qualifier"},
+			args: []string{"test.namespace-dash-dot", "test-name", "1.0.0-qualifier"},
 			want: &DefinitionID{
-				Namespace: "test.namespace-id",
-				Name:      "testId",
+				Namespace: "test.namespace-dash-dot",
+				Name:      "test-name",
 				Version:   "1.0.0-qualifier",
 			},
 		},
@@ -120,7 +120,7 @@ func TestDefinitionIDNewDefinitionID(t *testing.T) {
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
 			got := NewDefinitionID(testCase.args[0], testCase.args[1], testCase.args[2])
-			internal.AssertEqual(t, got, testCase.want)
+			internal.AssertEqual(t, testCase.want, got)
 		})
 	}
 }
@@ -128,14 +128,14 @@ func TestDefinitionIDNewDefinitionID(t *testing.T) {
 func TestDefinitionIDString(t *testing.T) {
 	testDefinitionID := &DefinitionID{
 		Namespace: "test.namespace",
-		Name:      "testId",
+		Name:      "test-name",
 		Version:   "1.0.0",
 	}
 
-	want := "test.namespace:testId:1.0.0"
+	want := "test.namespace:test-name:1.0.0"
 
 	got := testDefinitionID.String()
-	internal.AssertEqual(t, got, want)
+	internal.AssertEqual(t, want, got)
 
 	if got := testDefinitionID.String(); reflect.TypeOf(got) != reflect.TypeOf(want) {
 		t.Errorf("DefinitionID.String() = %v, want %v", reflect.TypeOf(got), reflect.TypeOf(want))
@@ -145,14 +145,14 @@ func TestDefinitionIDString(t *testing.T) {
 func TestDefinitionIDMarshalJSON(t *testing.T) {
 	testDefinitionID := &DefinitionID{
 		Namespace: "test.namespace",
-		Name:      "testId",
+		Name:      "test-name",
 		Version:   "1.0.0",
 	}
 
-	want := []byte("\"test.namespace:testId:1.0.0\"")
+	want := []byte("\"test.namespace:test-name:1.0.0\"")
 
 	got, _ := testDefinitionID.MarshalJSON()
-	internal.AssertEqual(t, got, want)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestDefinitionIDUnmarshalJSON(t *testing.T) {
@@ -162,32 +162,32 @@ func TestDefinitionIDUnmarshalJSON(t *testing.T) {
 		wantErr error
 	}{
 		"test_definition_id_unmarshal_json_valid": {
-			arg: []byte("\"test.namespace:testId:1.0.0\""),
+			arg: []byte("\"test.namespace:test-name:1.0.0\""),
 			want: &DefinitionID{
 				Namespace: "test.namespace",
-				Name:      "testId",
+				Name:      "test-name",
 				Version:   "1.0.0",
 			},
 			wantErr: nil,
 		},
 		"test_definition_id_unmarshal_json_invalid_namespace": {
-			arg:     []byte("\"test:namespace:testId:1.0.0\""),
-			wantErr: errors.New("invalid DefinitionID: test:namespace:testId:1.0.0"),
+			arg:     []byte("\"test:namespace:test-name:1.0.0\""),
+			wantErr: errors.New("invalid DefinitionID: test:namespace:test-name:1.0.0"),
 		},
 		"test_definition_id_unmarshal_json_invalid_name": {
 			arg:     []byte("\"test.namespace:1.0.0\""),
 			wantErr: errors.New("invalid DefinitionID: test.namespace:1.0.0"),
 		},
 		"test_definition_id_unmarshal_json_invalid_version": {
-			arg:     []byte("\"test.namespace:testId\""),
-			wantErr: errors.New("invalid DefinitionID: test.namespace:testId"),
+			arg:     []byte("\"test.namespace:test-name\""),
+			wantErr: errors.New("invalid DefinitionID: test.namespace:test-name"),
 		},
 		"test_definition_id_unmarshal_json_empty": {
 			arg:     []byte(""),
 			wantErr: errors.New("unexpected end of JSON input"),
 		},
 		"test_definition_id_unmarshal_json_invalid_argument": {
-			arg:     []byte("test.namespace:testId:1.0.0"),
+			arg:     []byte("test.namespace:test-name:1.0.0"),
 			wantErr: errors.New("invalid character 'e' in literal true (expecting 'r')"),
 		},
 	}
@@ -197,9 +197,9 @@ func TestDefinitionIDUnmarshalJSON(t *testing.T) {
 			got := &DefinitionID{}
 			err := got.UnmarshalJSON(testCase.arg)
 			if testCase.wantErr != nil {
-				internal.AssertError(t, err, testCase.wantErr)
+				internal.AssertError(t, testCase.wantErr, err)
 			} else {
-				internal.AssertEqual(t, got, testCase.want)
+				internal.AssertEqual(t, testCase.want, got)
 			}
 		})
 	}
@@ -207,7 +207,7 @@ func TestDefinitionIDUnmarshalJSON(t *testing.T) {
 
 func TestDefinitionIDWithNamespace(t *testing.T) {
 	testDefinitionID := &DefinitionID{
-		Name:    "testId",
+		Name:    "test-name",
 		Version: "1.0.0",
 	}
 
@@ -215,12 +215,12 @@ func TestDefinitionIDWithNamespace(t *testing.T) {
 
 	want := &DefinitionID{
 		Namespace: arg,
-		Name:      "testId",
+		Name:      "test-name",
 		Version:   "1.0.0",
 	}
 
 	got := testDefinitionID.WithNamespace(arg)
-	internal.AssertEqual(t, got, want)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestDefinitionIDWithName(t *testing.T) {
@@ -238,23 +238,23 @@ func TestDefinitionIDWithName(t *testing.T) {
 	}
 
 	got := testDefinitionID.WithName(arg)
-	internal.AssertEqual(t, got, want)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestDefinitionIDWithVersion(t *testing.T) {
 	testDefinitionID := &DefinitionID{
 		Namespace: "test.namespace",
-		Name:      "testId",
+		Name:      "test-name",
 	}
 
 	arg := "1.0.0"
 
 	want := &DefinitionID{
 		Namespace: "test.namespace",
-		Name:      "testId",
+		Name:      "test-name",
 		Version:   arg,
 	}
 
 	got := testDefinitionID.WithVersion(arg)
-	internal.AssertEqual(t, got, want)
+	internal.AssertEqual(t, want, got)
 }

--- a/model/feature_test.go
+++ b/model/feature_test.go
@@ -12,64 +12,60 @@
 package model
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/eclipse/ditto-clients-golang/internal"
 )
 
 func TestFeatureWithDefinitionFrom(t *testing.T) {
-	tests := []struct {
-		name        string
+	tests := map[string]struct {
 		arg1        string
 		arg2        string
 		testFeature Feature
 		want        []*DefinitionID
 	}{
-		{
-			name:        "TestFeatureWithDefinitionFromWithoutExistingDefinitionID",
-			arg1:        "test.namespace:testId:1.0.0",
-			arg2:        "test.namespace:testId:1.0.1",
+		"test_feature_with_definition_from_without_existing_definition_ID": {
+			arg1:        "test.namespace:test-name:1.0.0",
+			arg2:        "test.namespace:test-name:1.0.1",
 			testFeature: Feature{},
 			want: []*DefinitionID{
-				NewDefinitionIDFrom("test.namespace:testId:1.0.0"),
-				NewDefinitionIDFrom("test.namespace:testId:1.0.1"),
+				NewDefinitionIDFrom("test.namespace:test-name:1.0.0"),
+				NewDefinitionIDFrom("test.namespace:test-name:1.0.1"),
 			},
 		},
-		{
-			name: "TestFeatureWithDefinitionFromWithExistingDefinitionID",
-			arg1: "test.namespace:testId:1.0.0",
-			arg2: "test.namespace:testId:1.0.1",
+		"test_feature_with_definition_from_with_existing_definition_ID": {
+			arg1: "test.namespace:test-name:1.0.0",
+			arg2: "test.namespace:test-name:1.0.1",
 			testFeature: Feature{
 				Definition: []*DefinitionID{
-					NewDefinitionIDFrom("test.namespace:testId:0.0.0"),
+					NewDefinitionIDFrom("test.namespace:test-name:0.0.0"),
 				},
 			},
 			want: []*DefinitionID{
-				NewDefinitionIDFrom("test.namespace:testId:1.0.0"),
-				NewDefinitionIDFrom("test.namespace:testId:1.0.1"),
+				NewDefinitionIDFrom("test.namespace:test-name:1.0.0"),
+				NewDefinitionIDFrom("test.namespace:test-name:1.0.1"),
 			},
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.testFeature.WithDefinitionFrom(tt.arg1, tt.arg2); !reflect.DeepEqual(got.Definition, tt.want) {
-				t.Errorf("Feature.WithDefinitionFrom() = %v, want %v", got.Definition, tt.want)
-			}
+	for testName, testCase := range tests {
+		t.Run(testName, func(t *testing.T) {
+			got := testCase.testFeature.WithDefinitionFrom(testCase.arg1, testCase.arg2)
+			internal.AssertEqual(t, testCase.want, got.Definition)
 		})
 	}
 }
 
 func TestFeatureWithDefinition(t *testing.T) {
-	arg1 := NewDefinitionIDFrom("test.namespace:testId:1.0.0")
-	arg2 := NewDefinitionIDFrom("test.namespace:testId:1.0.0")
+	arg1 := NewDefinitionIDFrom("test.namespace:test-name:1.0.0")
+	arg2 := NewDefinitionIDFrom("test.namespace:test-name:1.0.0")
 
 	testDefinitions := []*DefinitionID{arg1, arg2}
 
 	testFeature := &Feature{}
 
-	if got := testFeature.WithDefinition(arg1, arg2); !reflect.DeepEqual(got.Definition, testDefinitions) {
-		t.Errorf("Feature.WithDefinition() = %v, want %v", got.Definition, testDefinitions)
-	}
+	got := testFeature.WithDefinition(arg1, arg2)
+	internal.AssertEqual(t, testDefinitions, got.Definition)
 }
 
 func TestFeatureWithProperties(t *testing.T) {
@@ -79,22 +75,18 @@ func TestFeatureWithProperties(t *testing.T) {
 	}
 
 	testFeature := &Feature{}
-
-	if got := testFeature.WithProperties(arg); !reflect.DeepEqual(got.Properties, arg) {
-		t.Errorf("Feature.WithProperties() = %v, want %v", got.Properties, arg)
-	}
+	got := testFeature.WithProperties(arg)
+	internal.AssertEqual(t, arg, got.Properties)
 }
 
 func TestFeatureWithProperty(t *testing.T) {
-	tests := []struct {
-		name        string
+	tests := map[string]struct {
 		arg1        string
 		arg2        string
 		testFeature Feature
 		want        map[string]interface{}
 	}{
-		{
-			name:        "TestFeatureWithPropertyWithoutExistingProperty",
+		"test_feature_with_property_without_existing_property": {
 			arg1:        "test.key",
 			arg2:        "test.value",
 			testFeature: Feature{},
@@ -102,8 +94,7 @@ func TestFeatureWithProperty(t *testing.T) {
 				"test.key": "test.value",
 			},
 		},
-		{
-			name: "TestFeatureWithPropertyWithExistingProperty",
+		"test_feature_with_property_wWith_existing_property": {
 			arg1: "test.key1",
 			arg2: "test.value1",
 			testFeature: Feature{
@@ -118,11 +109,10 @@ func TestFeatureWithProperty(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.testFeature.WithProperty(tt.arg1, tt.arg2); !reflect.DeepEqual(got.Properties, tt.want) {
-				t.Errorf("Feature.WithProperty() = %v, want %v", got.Properties, tt.want)
-			}
+	for testName, testCase := range tests {
+		t.Run(testName, func(t *testing.T) {
+			got := testCase.testFeature.WithProperty(testCase.arg1, testCase.arg2)
+			internal.AssertEqual(t, testCase.want, got.Properties)
 		})
 	}
 }
@@ -135,21 +125,18 @@ func TestFeatureWithDesiredProperties(t *testing.T) {
 
 	testFeature := &Feature{}
 
-	if got := testFeature.WithDesiredProperties(arg); !reflect.DeepEqual(got.DesiredProperties, arg) {
-		t.Errorf("Feature.WithDesiredProperties() = %v, want %v", got.DesiredProperties, arg)
-	}
+	got := testFeature.WithDesiredProperties(arg)
+	internal.AssertEqual(t, arg, got.DesiredProperties)
 }
 
 func TestFeatureWithDesiredProperty(t *testing.T) {
-	tests := []struct {
-		name        string
+	tests := map[string]struct {
 		arg1        string
 		arg2        string
 		testFeature Feature
 		want        map[string]interface{}
 	}{
-		{
-			name:        "TestFeatureWithDesiredPropertyWithoutExistingDesiredProperty",
+		"test_feature_with_desired_property_without_existing_desired_property": {
 			arg1:        "test.key",
 			arg2:        "test.value",
 			testFeature: Feature{},
@@ -157,8 +144,7 @@ func TestFeatureWithDesiredProperty(t *testing.T) {
 				"test.key": "test.value",
 			},
 		},
-		{
-			name: "TestFeatureWithDesiredPropertyExistingPropertyDesiredProperty",
+		"test_feature_with_desired_property_existing_property_desired_property": {
 			arg1: "test.key1",
 			arg2: "test.value1",
 			testFeature: Feature{
@@ -173,11 +159,10 @@ func TestFeatureWithDesiredProperty(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.testFeature.WithDesiredProperty(tt.arg1, tt.arg2); !reflect.DeepEqual(got.DesiredProperties, tt.want) {
-				t.Errorf("Feature.WithDesiredProperty() = %v, want %v", got.DesiredProperties, tt.want)
-			}
+	for testName, testCase := range tests {
+		t.Run(testName, func(t *testing.T) {
+			got := testCase.testFeature.WithDesiredProperty(testCase.arg1, testCase.arg2)
+			internal.AssertEqual(t, testCase.want, got.DesiredProperties)
 		})
 	}
 }

--- a/model/namespace_id_test.go
+++ b/model/namespace_id_test.go
@@ -25,48 +25,60 @@ func TestNamespaceIDNewNamespacedID(t *testing.T) {
 		args []string
 		want *NamespacedID
 	}{
-		"test_new_namespaced_id_valid": {
-			args: []string{"test.namespace", "testId"},
+		"test_new_namespaced_ID_valid": {
+			args: []string{"test.namespace", "test-name"},
 			want: &NamespacedID{
 				Namespace: "test.namespace",
-				Name:      "testId",
+				Name:      "test-name",
 			},
 		},
-		"test_new_namespaced_id_invalid": {
-			args: []string{"test.namespace", "test/Id"},
+		"test_new_namespaced_ID_invalid_name_slash": {
+			args: []string{"test.namespace", "test/name"},
 			want: nil,
 		},
-		"test_new_namespaced_id_namespace_with_colon": {
-			args: []string{"test:namespace", "testId"},
+		"test_new_namespaced_ID_invalid_name_control_character": {
+			args: []string{"test.namespace", "test§name"},
 			want: nil,
 		},
-		"test_new_namespaced_id_namespace_with_dash": {
-			args: []string{"test-namespace", "testId"},
+		"test_new_namespaced_ID_invalid_empty_name": {
+			args: []string{"test.namespace", ""},
+			want: nil,
+		},
+		"test_new_namespaced_ID_namespace_with_colon": {
+			args: []string{"test:namespace", "test-name"},
+			want: nil,
+		},
+		"test_new_namespaced_ID_namespace_with_dash": {
+			args: []string{"test-namespace", "test-name"},
 			want: &NamespacedID{
 				Namespace: "test-namespace",
-				Name:      "testId",
+				Name:      "test-name",
 			},
 		},
-		"test_new_namespaced_id_namespace_with_multiple_dash": {
-			args: []string{"test-namespace-id", "testId"},
+		"test_new_namespaced_ID_namespace_with_multiple_dash": {
+			args: []string{"test-namespace-multiple-dash", "test-name"},
 			want: &NamespacedID{
-				Namespace: "test-namespace-id",
-				Name:      "testId",
+				Namespace: "test-namespace-multiple-dash",
+				Name:      "test-name",
 			},
 		},
-		"test_new_namespaced_id_namespace_with_dash_dot": {
-			args: []string{"test.namespace-id", "testId"},
+		"test_new_namespaced_ID_namespace_with_dash_dot": {
+			args: []string{"test.namespace-dash-dot", "test-name"},
 			want: &NamespacedID{
-				Namespace: "test.namespace-id",
-				Name:      "testId",
+				Namespace: "test.namespace-dash-dot",
+				Name:      "test-name",
 			},
+		},
+		"test_new_namespaced_ID_invalid_namespace_control_character": {
+			args: []string{"test.namespace§", "test-name"},
+			want: nil,
 		},
 	}
 
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
 			got := NewNamespacedID(testCase.args[0], testCase.args[1])
-			internal.AssertEqual(t, got, testCase.want)
+			internal.AssertEqual(t, testCase.want, got)
 		})
 	}
 }
@@ -76,51 +88,51 @@ func TestNamespaceIDNewNamespacedIDFrom(t *testing.T) {
 		arg  string
 		want *NamespacedID
 	}{
-		"test_new_namespaced_id_from_valid": {
-			arg: "test.namespace_42:testId",
+		"test_new_namespaced_ID_from_valid": {
+			arg: "test.namespace_42:test-name",
 			want: &NamespacedID{
 				Namespace: "test.namespace_42",
-				Name:      "testId",
+				Name:      "test-name",
 			},
 		},
-		"test_new_namespaced_id_from_with_namespace_with_pascal_case": {
-			arg: "Test.Namespace_42:testId",
+		"test_new_namespaced_ID_from_with_namespace_with_pascal_case": {
+			arg: "Test.Namespace_42:test-name",
 			want: &NamespacedID{
 				Namespace: "Test.Namespace_42",
-				Name:      "testId",
+				Name:      "test-name",
 			},
 		},
-		"test_new_namespaced_id_from_without_namespace": {
-			arg: ":testId",
+		"test_new_namespaced_ID_from_without_namespace": {
+			arg: ":test-name",
 			want: &NamespacedID{
 				Namespace: "",
-				Name:      "testId",
+				Name:      "test-name",
 			},
 		},
-		"test_new_namespaced_id_from_with_double_colon": {
-			arg: "test.namespace:testId:testId",
+		"test_new_namespaced_ID_from_with_double_colon": {
+			arg: "test.namespace:test-name:test-name",
 			want: &NamespacedID{
 				Namespace: "test.namespace",
-				Name:      "testId:testId",
+				Name:      "test-name:test-name",
 			},
 		},
-		"test_new_namespaced_id_from_without_name": {
-			arg:  "test.namsepsaced",
+		"test_new_namespaced_ID_from_without_name": {
+			arg:  "test.namsepsace",
 			want: nil,
 		},
-		"test_new_namespaced_id_from_with_name_with_slash": {
-			arg:  "test.namespace:testId/testId",
+		"test_new_namespaced_ID_from_with_name_with_slash": {
+			arg:  "test.namespace:test-name/test-name",
 			want: nil,
 		},
-		"test_new_namespaced_id_from_with_name_with_control_character": {
-			arg:  "test.namespace:testId\ntestId",
+		"test_new_namespaced_ID_from_with_name_with_control_character": {
+			arg:  "test.namespace:test-name§test-name",
 			want: nil,
 		},
-		"test_new_namespaced_id_from_empty": {
+		"test_new_namespaced_ID_from_empty": {
 			arg:  "",
 			want: nil,
 		},
-		"test_new_namespaced_id_from_invalid_length": {
+		"test_new_namespaced_ID_from_invalid_length": {
 			arg: func() string {
 				letters := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 				generated := make([]byte, 257)
@@ -132,25 +144,25 @@ func TestNamespaceIDNewNamespacedIDFrom(t *testing.T) {
 			}(),
 			want: nil,
 		},
-		"test_new_namsepaced_id_from_with_namespace_with_single_dash": {
-			arg: "test-namespace:testId",
+		"test_new_namsepaced_ID_from_with_namespace_with_single_dash": {
+			arg: "test-namespace:test-name",
 			want: &NamespacedID{
 				Namespace: "test-namespace",
-				Name:      "testId",
+				Name:      "test-name",
 			},
 		},
-		"test_new_namsepaced_id_from_with_namespace_with_multiple_dash": {
-			arg: "test-namespace-id:testId",
+		"test_new_namsepaced_ID_from_with_namespace_with_multiple_dash": {
+			arg: "test-namespace-multiple-dash:test-name",
 			want: &NamespacedID{
-				Namespace: "test-namespace-id",
-				Name:      "testId",
+				Namespace: "test-namespace-multiple-dash",
+				Name:      "test-name",
 			},
 		},
-		"test_new_namsepaced_id_from_with_namespace_with_dash_dot": {
-			arg: "test.namespace-id:testId",
+		"test_new_namsepaced_ID_from_with_namespace_with_dash_dot": {
+			arg: "test.namespace-dash-dot:test-name",
 			want: &NamespacedID{
-				Namespace: "test.namespace-id",
-				Name:      "testId",
+				Namespace: "test.namespace-dash-dot",
+				Name:      "test-name",
 			},
 		},
 	}
@@ -158,7 +170,7 @@ func TestNamespaceIDNewNamespacedIDFrom(t *testing.T) {
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
 			got := NewNamespacedIDFrom(testCase.arg)
-			internal.AssertEqual(t, got, testCase.want)
+			internal.AssertEqual(t, testCase.want, got)
 		})
 	}
 }
@@ -166,13 +178,13 @@ func TestNamespaceIDNewNamespacedIDFrom(t *testing.T) {
 func TestNamespaceIDString(t *testing.T) {
 	testNamespaceID := &NamespacedID{
 		Namespace: "test.namespace",
-		Name:      "testId",
+		Name:      "test-name",
 	}
 
-	want := "test.namespace:testId"
+	want := "test.namespace:test-name"
 
 	got := testNamespaceID.String()
-	internal.AssertEqual(t, got, want)
+	internal.AssertEqual(t, want, got)
 
 	if reflect.TypeOf(got) != reflect.TypeOf(want) {
 		t.Errorf("NamespaceID.String() = %v, want %v", reflect.TypeOf(got), reflect.TypeOf(want))
@@ -182,13 +194,13 @@ func TestNamespaceIDString(t *testing.T) {
 func TestNamespaceIDMarshalJSON(t *testing.T) {
 	testNamespace := &NamespacedID{
 		Namespace: "test.namespace",
-		Name:      "testId",
+		Name:      "test-name",
 	}
 
-	want := []byte("\"test.namespace:testId\"")
+	want := []byte("\"test.namespace:test-name\"")
 
 	got, _ := testNamespace.MarshalJSON()
-	internal.AssertEqual(t, got, want)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestNamespaceIDUnmarshalJSON(t *testing.T) {
@@ -197,40 +209,40 @@ func TestNamespaceIDUnmarshalJSON(t *testing.T) {
 		want    *NamespacedID
 		wantErr error
 	}{
-		"test_namespaced_id_unmarshal_json_valid": {
-			arg: []byte("\"test.namespace:testId\""),
+		"test_namespaced_ID_unmarshal_json_valid": {
+			arg: []byte("\"test.namespace:test-name\""),
 			want: &NamespacedID{
 				Namespace: "test.namespace",
-				Name:      "testId",
+				Name:      "test-name",
 			},
 			wantErr: nil,
 		},
-		"test_namespace_id_unmarshal_json_namespace_dash": {
-			arg: []byte("\"test-namespace:testId\""),
+		"test_namespace_ID_unmarshal_json_namespace_dash": {
+			arg: []byte("\"test-namespace:test-name\""),
 			want: &NamespacedID{
 				Namespace: "test-namespace",
-				Name:      "testId",
+				Name:      "test-name",
 			},
 			wantErr: nil,
 		},
-		"test_namespace_id_unmarshal_json_namespace_dash_dot": {
-			arg: []byte("\"test.namespace-id:testId\""),
+		"test_namespace_ID_unmarshal_json_namespace_dash_dot": {
+			arg: []byte("\"test.namespace-dash-dot:test-name\""),
 			want: &NamespacedID{
-				Namespace: "test.namespace-id",
-				Name:      "testId",
+				Namespace: "test.namespace-dash-dot",
+				Name:      "test-name",
 			},
 			wantErr: nil,
 		},
-		"test_namespaced_id_unmarshal_json_invalid": {
-			arg: []byte("\"test:namespace\\testId\""),
-			wantErr: errors.New("invalid NamespacedID: test:namespace	estId"),
+		"test_namespaced_ID_unmarshal_json_invalid": {
+			arg: []byte("\"test:namespace\\test-name\""),
+			wantErr: errors.New("invalid NamespacedID: test:namespace	est-name"),
 		},
-		"test_namespaced_id_unmarshal_json_empty": {
+		"test_namespaced_ID_unmarshal_json_empty": {
 			arg:     []byte(""),
 			wantErr: errors.New("unexpected end of JSON input"),
 		},
-		"test_namespaced_id_unmarshal_json_invalid_argument": {
-			arg:     []byte("test.namespace:testId"),
+		"test_namespaced_ID_unmarshal_json_invalid_argument": {
+			arg:     []byte("test.namespace:test-name"),
 			wantErr: errors.New("invalid character 'e' in literal true (expecting 'r')"),
 		},
 	}
@@ -240,9 +252,9 @@ func TestNamespaceIDUnmarshalJSON(t *testing.T) {
 			got := &NamespacedID{}
 			err := got.UnmarshalJSON(testCase.arg)
 			if testCase.wantErr != nil {
-				internal.AssertError(t, err, testCase.wantErr)
+				internal.AssertError(t, testCase.wantErr, err)
 			} else {
-				internal.AssertEqual(t, got, testCase.want)
+				internal.AssertEqual(t, testCase.want, got)
 			}
 		})
 	}
@@ -250,18 +262,18 @@ func TestNamespaceIDUnmarshalJSON(t *testing.T) {
 
 func TestNamespaceIDWithNamespace(t *testing.T) {
 	testNamespaceID := &NamespacedID{
-		Name: "testId",
+		Name: "test-name",
 	}
 
 	arg := "test.namespace"
 
 	want := &NamespacedID{
 		Namespace: arg,
-		Name:      "testId",
+		Name:      "test-name",
 	}
 
 	got := testNamespaceID.WithNamespace(arg)
-	internal.AssertEqual(t, got, want)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestNamespaceIDWithName(t *testing.T) {
@@ -269,13 +281,13 @@ func TestNamespaceIDWithName(t *testing.T) {
 		Namespace: "test.namespace",
 	}
 
-	arg := "testId"
+	arg := "test-name"
 
 	want := &NamespacedID{
 		Namespace: "test.namespace",
-		Name:      "testId",
+		Name:      "test-name",
 	}
 
 	got := testNamespace.WithName(arg)
-	internal.AssertEqual(t, got, want)
+	internal.AssertEqual(t, want, got)
 }

--- a/model/namespaced_id.go
+++ b/model/namespaced_id.go
@@ -90,7 +90,7 @@ func (nsID *NamespacedID) WithName(name string) *NamespacedID {
 
 func validateNamespacedID(nsIDString string) ([]string, error) {
 	if len(nsIDString) > 256 {
-		return nil, errors.New("length exceeds 256, invalid NamespacedID" + nsIDString)
+		return nil, errors.New("length exceeds 256, invalid NamespacedID: " + nsIDString)
 	}
 	if matches := regexNamespacedID.FindStringSubmatch(nsIDString); len(matches) == 3 {
 		return matches, nil

--- a/model/thing_test.go
+++ b/model/thing_test.go
@@ -12,78 +12,73 @@
 package model
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/eclipse/ditto-clients-golang/internal"
 )
 
 func TestThingWithID(t *testing.T) {
 	arg := &NamespacedID{
 		Namespace: "test.namespace",
-		Name:      "testId",
+		Name:      "test-name",
 	}
 
 	testThing := &Thing{}
 
-	if got := testThing.WithID(arg); got.ID != arg {
-		t.Errorf("Thing.WithID() = %v, want %v", got.ID, arg)
-	}
+	got := testThing.WithID(arg)
+	internal.AssertEqual(t, arg, got.ID)
 }
 
 func TestThingWithIDFrom(t *testing.T) {
-	arg := "test.namespace:testId"
+	arg := "test.namespace:test-name"
 
 	testThing := &Thing{}
 
-	if got := testThing.WithIDFrom(arg); !reflect.DeepEqual(got.ID, NewNamespacedIDFrom(arg)) {
-		t.Errorf("Thing.WithIDFrom() = %v, want %v", got.ID, arg)
-	}
+	got := testThing.WithIDFrom(arg)
+	internal.AssertEqual(t, NewNamespacedIDFrom(arg), got.ID)
 }
 
 func TestThingWithDefinition(t *testing.T) {
 	arg := &DefinitionID{
 		Namespace: "test.namespace",
-		Name:      "testId",
+		Name:      "test-name",
 		Version:   "1.0.0",
 	}
 
 	testThing := &Thing{}
 
-	if got := testThing.WithDefinition(arg); got.DefinitionID != arg {
-		t.Errorf("Thing.WithDefinition() = %v, want %v", got.DefinitionID, arg)
-	}
+	got := testThing.WithDefinition(arg)
+	internal.AssertEqual(t, arg, got.DefinitionID)
 }
 
 func TestThingWithDefinitionFrom(t *testing.T) {
-	arg := "test.namespace:testId:1.0.0"
+	arg := "test.namespace:test-name:1.0.0"
 
 	testThing := &Thing{}
 
-	if got := testThing.WithDefinitionFrom(arg); !reflect.DeepEqual(got.DefinitionID, NewDefinitionIDFrom(arg)) {
-		t.Errorf("Thing.WithDefinitionFrom() = %v, want %v", got.DefinitionID, arg)
-	}
+	got := testThing.WithDefinitionFrom(arg)
+	internal.AssertEqual(t, NewDefinitionIDFrom(arg), got.DefinitionID)
 }
 
 func TestThingWithPolicyID(t *testing.T) {
 	arg := &NamespacedID{
 		Namespace: "test.namespace",
-		Name:      "testId",
+		Name:      "test-name",
 	}
 
 	testThing := &Thing{}
 
-	if got := testThing.WithPolicyID(arg); got.PolicyID != arg {
-		t.Errorf("Thing.WithPolicyID() = %v, want %v", got.PolicyID, arg)
-	}
+	got := testThing.WithPolicyID(arg)
+	internal.AssertEqual(t, arg, got.PolicyID)
 }
 
 func TestThingPolicyIDFrom(t *testing.T) {
-	arg := "test.namespace:testId"
+	arg := "test.namespace:test-name"
 
 	testThing := &Thing{}
 
-	if got := testThing.WithPolicyIDFrom(arg); !reflect.DeepEqual(got.PolicyID, NewNamespacedIDFrom(arg)) {
-		t.Errorf("Thing.WithPolicyIDFrom() = %v, want %v", got.PolicyID, arg)
-	}
+	got := testThing.WithPolicyIDFrom(arg)
+	internal.AssertEqual(t, NewNamespacedIDFrom(arg), got.PolicyID)
 }
 
 func TestThingWithAttributes(t *testing.T) {
@@ -93,21 +88,18 @@ func TestThingWithAttributes(t *testing.T) {
 
 	testThing := &Thing{}
 
-	if got := testThing.WithAttributes(arg); !reflect.DeepEqual(got.Attributes, arg) {
-		t.Errorf("Thing.WithAttributes() = %v, want %v", got.Attributes, arg)
-	}
+	got := testThing.WithAttributes(arg)
+	internal.AssertEqual(t, arg, got.Attributes)
 }
 
 func TestThingWithAttribute(t *testing.T) {
-	tests := []struct {
-		name      string
+	tests := map[string]struct {
 		arg1      string
 		arg2      interface{}
 		testThing Thing
 		want      map[string]interface{}
 	}{
-		{
-			name:      "TestThingWithAttributeWithoutExistingAttributes",
+		"test_thing_with_attribute_without_existing_attributes": {
 			arg1:      "test.key1",
 			arg2:      1.0,
 			testThing: Thing{},
@@ -115,8 +107,7 @@ func TestThingWithAttribute(t *testing.T) {
 				"test.key1": 1.0,
 			},
 		},
-		{
-			name: "TestThingWithAttributeWithExistingAttributes",
+		"test_thing_with_attribute_with_existing_attributes": {
 			arg1: "test.key1",
 			arg2: "test.value1",
 			testThing: Thing{
@@ -131,11 +122,10 @@ func TestThingWithAttribute(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.testThing.WithAttribute(tt.arg1, tt.arg2); !reflect.DeepEqual(got.Attributes, tt.want) {
-				t.Errorf("Thing.WithAttribute() = %v, want %v", got.Attributes, tt.want)
-			}
+	for testName, testCase := range tests {
+		t.Run(testName, func(t *testing.T) {
+			got := testCase.testThing.WithAttribute(testCase.arg1, testCase.arg2)
+			internal.AssertEqual(t, testCase.want, got.Attributes)
 		})
 	}
 }
@@ -145,7 +135,7 @@ func TestThingWitFeatures(t *testing.T) {
 		"TestFeature": {
 			Definition: []*DefinitionID{{
 				Namespace: "test.namespace",
-				Name:      "testId",
+				Name:      "test-name",
 				Version:   "1.0.0",
 			}},
 			Properties: map[string]interface{}{
@@ -156,26 +146,23 @@ func TestThingWitFeatures(t *testing.T) {
 
 	testThing := &Thing{}
 
-	if got := testThing.WithFeatures(arg); !reflect.DeepEqual(got.Features, arg) {
-		t.Errorf("Thing.WithFeatures() = %v, want %v", got.Features, arg)
-	}
+	got := testThing.WithFeatures(arg)
+	internal.AssertEqual(t, arg, got.Features)
 }
 
 func TestThingWithFeature(t *testing.T) {
-	tests := []struct {
-		name      string
+	tests := map[string]struct {
 		arg1      string
 		arg2      *Feature
 		testThing Thing
 		want      map[string]*Feature
 	}{
-		{
-			name: "TestThingWithFeatureWithoutExistingFeature",
+		"test_thing_with_feature_without_existing_feature": {
 			arg1: "TestFeature",
 			arg2: &Feature{
 				Definition: []*DefinitionID{{
 					Namespace: "test.namespace",
-					Name:      "testId",
+					Name:      "test-name",
 					Version:   "1.0.0",
 				}},
 				Properties: map[string]interface{}{
@@ -187,7 +174,7 @@ func TestThingWithFeature(t *testing.T) {
 				"TestFeature": {
 					Definition: []*DefinitionID{{
 						Namespace: "test.namespace",
-						Name:      "testId",
+						Name:      "test-name",
 						Version:   "1.0.0",
 					}},
 					Properties: map[string]interface{}{
@@ -196,8 +183,7 @@ func TestThingWithFeature(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "TestThingWithFeatureWithExistingFeature",
+		"test_thing_with_feature_with_existing_feature": {
 			arg1: "TestFeature1",
 			arg2: &Feature{
 				Properties: map[string]interface{}{
@@ -220,11 +206,10 @@ func TestThingWithFeature(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.testThing.WithFeature(tt.arg1, tt.arg2); !reflect.DeepEqual(got.Features, tt.want) {
-				t.Errorf("Thing.WithFeature() = %v, want %v", got.Features, tt.want)
-			}
+	for testName, testCase := range tests {
+		t.Run(testName, func(t *testing.T) {
+			got := testCase.testThing.WithFeature(testCase.arg1, testCase.arg2)
+			internal.AssertEqual(t, testCase.want, got.Features)
 		})
 	}
 }

--- a/protocol/envelope_test.go
+++ b/protocol/envelope_test.go
@@ -12,8 +12,9 @@
 package protocol
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/eclipse/ditto-clients-golang/internal"
 )
 
 func TestEnvelopeWithTopic(t *testing.T) {
@@ -27,9 +28,9 @@ func TestEnvelopeWithTopic(t *testing.T) {
 			Action:     ActionSubscribe,
 		}
 		msg := &Envelope{}
-		if got := msg.WithTopic(arg); !reflect.DeepEqual(got.Topic, arg) {
-			t.Errorf("Envelope.WithTopic() = %v, want %v", got.Topic, arg)
-		}
+
+		got := msg.WithTopic(arg)
+		internal.AssertEqual(t, arg, got.Topic)
 	})
 }
 
@@ -37,9 +38,9 @@ func TestEnvelopeWithHeaders(t *testing.T) {
 	t.Run("TestEnvelopeWithHeaders", func(t *testing.T) {
 		arg := NewHeaders(WithChannel("something"))
 		msg := &Envelope{}
-		if got := msg.WithHeaders(arg); !reflect.DeepEqual(got.Headers, arg) {
-			t.Errorf("Envelope.WithHeaders() = %v, want %v", got.Headers, arg)
-		}
+
+		got := msg.WithHeaders(arg)
+		internal.AssertEqual(t, arg, got.Headers)
 	})
 }
 
@@ -47,9 +48,9 @@ func TestEnvelopeWithPath(t *testing.T) {
 	t.Run("TestEnvelopeWithPath", func(t *testing.T) {
 		arg := "somePath"
 		msg := &Envelope{}
-		if got := msg.WithPath(arg); !reflect.DeepEqual(got.Path, arg) {
-			t.Errorf("Envelope.WithPath() = %v, want %v", got.Path, arg)
-		}
+
+		got := msg.WithPath(arg)
+		internal.AssertEqual(t, arg, got.Path)
 	})
 }
 
@@ -57,9 +58,9 @@ func TestEnvelopeWithValue(t *testing.T) {
 	t.Run("TestEnvelopeWithValue", func(t *testing.T) {
 		arg := "someValue"
 		msg := &Envelope{}
-		if got := msg.WithValue(arg); !reflect.DeepEqual(got.Value, arg) {
-			t.Errorf("Envelope.WithValue() = %v, want %v", got.Value, arg)
-		}
+
+		got := msg.WithValue(arg)
+		internal.AssertEqual(t, arg, got.Value)
 	})
 }
 
@@ -67,9 +68,9 @@ func TestEnvelopeWithFields(t *testing.T) {
 	t.Run("TestEnvelopeWithFields", func(t *testing.T) {
 		arg := "someFields"
 		msg := &Envelope{}
-		if got := msg.WithFields(arg); !reflect.DeepEqual(got.Fields, arg) {
-			t.Errorf("Envelope.WithFields() = %v, want %v", got.Fields, arg)
-		}
+
+		got := msg.WithFields(arg)
+		internal.AssertEqual(t, arg, got.Fields)
 	})
 }
 
@@ -77,9 +78,9 @@ func TestEnvelopeWithExtra(t *testing.T) {
 	t.Run("TestEnvelopeWithExtra", func(t *testing.T) {
 		arg := "Extra"
 		msg := &Envelope{}
-		if got := msg.WithExtra(arg); !reflect.DeepEqual(got.Extra, arg) {
-			t.Errorf("Envelope.WithExtra() = %v, want %v", got.Extra, arg)
-		}
+
+		got := msg.WithExtra(arg)
+		internal.AssertEqual(t, arg, got.Extra)
 	})
 }
 
@@ -87,9 +88,9 @@ func TestEnvelopeWithStatus(t *testing.T) {
 	t.Run("TestEnvelopeWithStatus", func(t *testing.T) {
 		arg := 202
 		msg := &Envelope{}
-		if got := msg.WithStatus(arg); !reflect.DeepEqual(got.Status, arg) {
-			t.Errorf("Envelope.WithStatus() = %v, want %v", got.Status, arg)
-		}
+
+		got := msg.WithStatus(arg)
+		internal.AssertEqual(t, arg, got.Status)
 	})
 }
 
@@ -97,9 +98,9 @@ func TestEnvelopeWithRevision(t *testing.T) {
 	t.Run("TestEnvelopeWithRevision", func(t *testing.T) {
 		arg := int64(1001)
 		msg := &Envelope{}
-		if got := msg.WithRevision(arg); !reflect.DeepEqual(got.Revision, arg) {
-			t.Errorf("Envelope.WithRevision() = %v, want %v", got.Revision, arg)
-		}
+
+		got := msg.WithRevision(arg)
+		internal.AssertEqual(t, arg, got.Revision)
 	})
 }
 
@@ -107,8 +108,8 @@ func TestEnvelopeWithTimestamp(t *testing.T) {
 	t.Run("TestEnvelopeWithTimestamp", func(t *testing.T) {
 		arg := "10"
 		msg := &Envelope{}
-		if got := msg.WithTimestamp(arg); !reflect.DeepEqual(got.Timestamp, arg) {
-			t.Errorf("Envelope.WithTimestamp() = %v, want %v", got.Timestamp, arg)
-		}
+
+		got := msg.WithTimestamp(arg)
+		internal.AssertEqual(t, arg, got.Timestamp)
 	})
 }

--- a/protocol/headers_opts_test.go
+++ b/protocol/headers_opts_test.go
@@ -15,6 +15,8 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+
+	"github.com/eclipse/ditto-clients-golang/internal"
 )
 
 func WithError() HeaderOpt {
@@ -88,134 +90,134 @@ func TestNewHeaders(t *testing.T) {
 func TestWithCorrelationID(t *testing.T) {
 	t.Run("TestWithCorrelationID", func(t *testing.T) {
 		cid := "correlationId"
-		if got := NewHeaders(WithCorrelationID(cid)); !reflect.DeepEqual(got.CorrelationID(), cid) {
-			t.Errorf("WithCorrelationID() = %v, want %v", got.CorrelationID(), cid)
-		}
+
+		got := NewHeaders(WithCorrelationID(cid))
+		internal.AssertEqual(t, cid, got.CorrelationID())
 	})
 }
 
 func TestWithReplyTo(t *testing.T) {
 	t.Run("TestWithReplyTo", func(t *testing.T) {
 		rto := "replyto"
-		if got := NewHeaders(WithReplyTo(rto)); !reflect.DeepEqual(got.ReplyTo(), rto) {
-			t.Errorf("WithReplyTo() = %v, want %v", got.ReplyTo(), rto)
-		}
+
+		got := NewHeaders(WithReplyTo(rto))
+		internal.AssertEqual(t, rto, got.ReplyTo())
 	})
 }
 
 func TestWithReplyTarget(t *testing.T) {
 	t.Run("TestWithReplyTarget", func(t *testing.T) {
 		rt := "11111"
-		if got := NewHeaders(WithReplyTarget(rt)); !reflect.DeepEqual(got.Values[HeaderReplyTarget], rt) {
-			t.Errorf("WithReplyTarget() = %v, want %v", got.Values[HeaderReplyTarget], rt)
-		}
+
+		got := NewHeaders(WithReplyTarget(rt))
+		internal.AssertEqual(t, rt, got.Values[HeaderReplyTarget])
 	})
 }
 
 func TestWithChannel(t *testing.T) {
 	t.Run("TestWithChannel", func(t *testing.T) {
 		cha := "channel"
-		if got := NewHeaders(WithChannel(cha)); !reflect.DeepEqual(got.Channel(), cha) {
-			t.Errorf("WithChannel() = %v, want %v", got.Channel(), cha)
-		}
+
+		got := NewHeaders(WithChannel(cha))
+		internal.AssertEqual(t, cha, got.Channel())
 	})
 }
 
 func TestWithResponseRequired(t *testing.T) {
 	t.Run("TestWithResponseRequired", func(t *testing.T) {
 		rrq := true
-		if got := NewHeaders(WithResponseRequired(rrq)); !reflect.DeepEqual(got.IsResponseRequired(), rrq) {
-			t.Errorf("WithResponseRequired() = %v, want %v", got.IsResponseRequired(), rrq)
-		}
+
+		got := NewHeaders(WithResponseRequired(rrq))
+		internal.AssertEqual(t, rrq, got.IsResponseRequired())
 	})
 }
 
 func TestWithOriginator(t *testing.T) {
 	t.Run("TestWithOriginator", func(t *testing.T) {
 		org := "originator"
-		if got := NewHeaders(WithOriginator(org)); !reflect.DeepEqual(got.Originator(), org) {
-			t.Errorf("WithOriginator() = %v, want %v", got.Originator(), org)
-		}
+
+		got := NewHeaders(WithOriginator(org))
+		internal.AssertEqual(t, org, got.Originator())
 	})
 }
 
 func TestWithOrigin(t *testing.T) {
 	t.Run("TestWithOrigin", func(t *testing.T) {
 		org := "origin"
-		if got := NewHeaders(WithOrigin(org)); !reflect.DeepEqual(got.Origin(), org) {
-			t.Errorf("WithOrigin() = %v, want %v", got.Origin(), org)
-		}
+
+		got := NewHeaders(WithOrigin(org))
+		internal.AssertEqual(t, org, got.Origin())
 	})
 }
 
 func TestWithDryRun(t *testing.T) {
 	t.Run("TestWithDryRun", func(t *testing.T) {
 		dry := true
-		if got := NewHeaders(WithDryRun(dry)); !reflect.DeepEqual(got.IsDryRun(), dry) {
-			t.Errorf("WithDryRun() = %v, want %v", got.IsDryRun(), dry)
-		}
+
+		got := NewHeaders(WithDryRun(dry))
+		internal.AssertEqual(t, dry, got.IsDryRun())
 	})
 }
 
 func TestWithETag(t *testing.T) {
 	t.Run("TestWithETag", func(t *testing.T) {
 		et := "etag"
-		if got := NewHeaders(WithETag(et)); !reflect.DeepEqual(got.ETag(), et) {
-			t.Errorf("WithETag() = %v, want %v", got.ETag(), et)
-		}
+
+		got := NewHeaders(WithETag(et))
+		internal.AssertEqual(t, et, got.ETag())
 	})
 }
 
 func TestWithIfMatch(t *testing.T) {
 	t.Run("TestWithIfMatch", func(t *testing.T) {
 		im := "ifMatch"
-		if got := NewHeaders(WithIfMatch(im)); !reflect.DeepEqual(got.IfMatch(), im) {
-			t.Errorf("WithIfMatch() = %v, want %v", got.IfMatch(), im)
-		}
+
+		got := NewHeaders(WithIfMatch(im))
+		internal.AssertEqual(t, im, got.IfMatch())
 	})
 }
 
 func TestWithIfNoneMatch(t *testing.T) {
 	t.Run("TestWithIfNoneMatch", func(t *testing.T) {
 		inm := "ifNoneMatch"
-		if got := NewHeaders(WithIfNoneMatch(inm)); !reflect.DeepEqual(got.IfNoneMatch(), inm) {
-			t.Errorf("WithIfNoneMatch() = %v, want %v", got.IfNoneMatch(), inm)
-		}
+
+		got := NewHeaders(WithIfNoneMatch(inm))
+		internal.AssertEqual(t, inm, got.IfNoneMatch())
 	})
 }
 
 func TestWithTimeout(t *testing.T) {
 	t.Run("TestWithTimeout", func(t *testing.T) {
 		tmo := "10"
-		if got := NewHeaders(WithTimeout(tmo)); !reflect.DeepEqual(got.Timeout(), tmo) {
-			t.Errorf("WithTimeout() = %v, want %v", got.Timeout(), tmo)
-		}
+
+		got := NewHeaders(WithTimeout(tmo))
+		internal.AssertEqual(t, tmo, got.Timeout())
 	})
 }
 
 func TestWithSchemaVersion(t *testing.T) {
 	t.Run("TestWithSchemaVersion", func(t *testing.T) {
 		sv := "123456789"
-		if got := NewHeaders(WithSchemaVersion("123456789")); !reflect.DeepEqual(got.Values[HeaderSchemaVersion], sv) {
-			t.Errorf("WithSchemaVersion() = %v, want %v", got.Values[HeaderSchemaVersion], sv)
-		}
+
+		got := NewHeaders(WithSchemaVersion("123456789"))
+		internal.AssertEqual(t, sv, got.Values[HeaderSchemaVersion])
 	})
 }
 
 func TestWithContentType(t *testing.T) {
 	t.Run("TestWithContentType", func(t *testing.T) {
 		hct := "contentType"
-		if got := NewHeaders(WithContentType(hct)); !reflect.DeepEqual(got.ContentType(), hct) {
-			t.Errorf("WithContentType() = %v, want %v", got.ContentType(), hct)
-		}
+
+		got := NewHeaders(WithContentType(hct))
+		internal.AssertEqual(t, hct, got.ContentType())
 	})
 }
 
 func TestWithGeneric(t *testing.T) {
 	t.Run("TestWithGeneric", func(t *testing.T) {
 		hct := "contentType"
-		if got := NewHeaders(WithGeneric(HeaderContentType, hct)); !reflect.DeepEqual(got.ContentType(), hct) {
-			t.Errorf("WithGeneric() = %v, want %v", got.ContentType(), hct)
-		}
+
+		got := NewHeaders(WithGeneric(HeaderContentType, hct))
+		internal.AssertEqual(t, hct, got.ContentType())
 	})
 }

--- a/protocol/headers_test.go
+++ b/protocol/headers_test.go
@@ -12,8 +12,9 @@
 package protocol
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/eclipse/ditto-clients-golang/internal"
 )
 
 func TestHeadersCorrelationID(t *testing.T) {
@@ -23,13 +24,14 @@ func TestHeadersCorrelationID(t *testing.T) {
 		h := &Headers{
 			Values: arg,
 		}
-		if got := h.CorrelationID(); got != "correlation-id" {
-			t.Errorf("Headers.CorrelationID() = %v, want %v", got, "correlation-id")
-		}
+
+		got := h.CorrelationID()
+		internal.AssertEqual(t, "correlation-id", got)
+
 		arg[HeaderCorrelationID] = nil
-		if got := h.CorrelationID(); got != "" {
-			t.Errorf("Headers.CorrelationID() nil = %v, want \"\"", got)
-		}
+
+		got = h.CorrelationID()
+		internal.AssertEqual(t, "", got)
 	})
 }
 
@@ -40,14 +42,13 @@ func TestHeadersTimeout(t *testing.T) {
 		h := &Headers{
 			Values: arg,
 		}
-		if got := h.Timeout(); got != "10" {
-			t.Errorf("Headers.Timeout() = %v, want %v", got, "10")
-		}
-		arg[HeaderTimeout] = nil
-		if got := h.Timeout(); got != "" {
-			t.Errorf("Headers.Timeout() nil = %v, want \"\"", got)
-		}
 
+		got := h.Timeout()
+		internal.AssertEqual(t, "10", got)
+
+		arg[HeaderTimeout] = nil
+		got = h.Timeout()
+		internal.AssertEqual(t, "", got)
 	})
 }
 
@@ -58,13 +59,13 @@ func TestHeadersIsResponseRequired(t *testing.T) {
 		h := &Headers{
 			Values: arg,
 		}
-		if got := h.IsResponseRequired(); got != false {
-			t.Errorf("Headers.IsResponseRequired() = %v, want %v", got, false)
-		}
+
+		got := h.IsResponseRequired()
+		internal.AssertFalse(t, got)
+
 		arg[HeaderResponseRequired] = nil
-		if got := h.IsResponseRequired(); got != false {
-			t.Errorf("Headers.IsResponseRequired() nil = %v, want %v", got, false)
-		}
+		got = h.IsResponseRequired()
+		internal.AssertFalse(t, got)
 	})
 }
 
@@ -75,13 +76,13 @@ func TestHeadersChannel(t *testing.T) {
 		h := &Headers{
 			Values: arg,
 		}
-		if got := h.Channel(); got != "1" {
-			t.Errorf("Headers.Channel() = %v, want %v", got, "1")
-		}
+
+		got := h.Channel()
+		internal.AssertEqual(t, "1", got)
+
 		arg[HeaderChannel] = nil
-		if got := h.Channel(); got != "" {
-			t.Errorf("Headers.Channel() nil = %v, want \"\"", got)
-		}
+		got = h.Channel()
+		internal.AssertEqual(t, "", got)
 	})
 }
 
@@ -92,13 +93,13 @@ func TestHeadersIsDryRun(t *testing.T) {
 		h := &Headers{
 			Values: arg,
 		}
-		if got := h.IsDryRun(); got != false {
-			t.Errorf("Headers.IsDryRun() = %v, want %v", got, false)
-		}
+
+		got := h.IsDryRun()
+		internal.AssertFalse(t, got)
+
 		arg[HeaderDryRun] = nil
-		if got := h.IsDryRun(); got != false {
-			t.Errorf("Headers.IsDryRun() nil = %v, want %v", got, false)
-		}
+		got = h.IsDryRun()
+		internal.AssertFalse(t, got)
 	})
 }
 
@@ -109,13 +110,13 @@ func TestHeadersOrigin(t *testing.T) {
 		h := &Headers{
 			Values: arg,
 		}
-		if got := h.Origin(); got != "origin" {
-			t.Errorf("Headers.Origin() = %v, want %v", got, "origin")
-		}
+
+		got := h.Origin()
+		internal.AssertEqual(t, "origin", got)
+
 		arg[HeaderOrigin] = nil
-		if got := h.Origin(); got != "" {
-			t.Errorf("Headers.Origin() nil = %v, want \"\"", got)
-		}
+		got = h.Origin()
+		internal.AssertEqual(t, "", got)
 	})
 }
 
@@ -126,13 +127,13 @@ func TestHeadersOriginator(t *testing.T) {
 		h := &Headers{
 			Values: arg,
 		}
-		if got := h.Originator(); got != "ditto-originator" {
-			t.Errorf("Headers.Originator() = %v, want %v", got, "ditto-originator")
-		}
+
+		got := h.Originator()
+		internal.AssertEqual(t, "ditto-originator", got)
+
 		arg[HeaderOriginator] = nil
-		if got := h.Originator(); got != "" {
-			t.Errorf("Headers.Originator() nil = %v, want \"\"", got)
-		}
+		got = h.Originator()
+		internal.AssertEqual(t, "", got)
 	})
 }
 
@@ -143,13 +144,13 @@ func TestHeadersETag(t *testing.T) {
 		h := &Headers{
 			Values: arg,
 		}
-		if got := h.ETag(); got != "1" {
-			t.Errorf("Headers.ETag() = %v, want %v", got, "1")
-		}
+
+		got := h.ETag()
+		internal.AssertEqual(t, "1", got)
+
 		arg[HeaderETag] = nil
-		if got := h.ETag(); got != "" {
-			t.Errorf("Headers.ETag() nil = %v, want \"\"", got)
-		}
+		got = h.ETag()
+		internal.AssertEqual(t, "", got)
 	})
 }
 
@@ -160,13 +161,13 @@ func TestHeadersIfMatch(t *testing.T) {
 		h := &Headers{
 			Values: arg,
 		}
-		if got := h.IfMatch(); got != "HeaderIfMatch" {
-			t.Errorf("Headers.IfMatch() = %v, want %v", got, "HeaderIfMatch")
-		}
+
+		got := h.IfMatch()
+		internal.AssertEqual(t, "HeaderIfMatch", got)
+
 		arg[HeaderIfMatch] = nil
-		if got := h.IfMatch(); got != "" {
-			t.Errorf("Headers.IfMatch() nil = %v, want \"\"", got)
-		}
+		got = h.IfMatch()
+		internal.AssertEqual(t, "", got)
 	})
 }
 
@@ -177,13 +178,13 @@ func TestHeadersIfNoneMatch(t *testing.T) {
 		h := &Headers{
 			Values: arg,
 		}
-		if got := h.IfNoneMatch(); got != "123" {
-			t.Errorf("Headers.IfNoneMatch() = %v, want %v", got, "123")
-		}
+
+		got := h.IfNoneMatch()
+		internal.AssertEqual(t, "123", got)
+
 		arg[HeaderIfNoneMatch] = nil
-		if got := h.IfNoneMatch(); got != "" {
-			t.Errorf("Headers.IfNoneMatch() nil = %v, want \"\"", got)
-		}
+		got = h.IfNoneMatch()
+		internal.AssertEqual(t, "", got)
 	})
 }
 
@@ -194,13 +195,13 @@ func TestHeadersReplyTarget(t *testing.T) {
 		h := &Headers{
 			Values: arg,
 		}
-		if got := h.ReplyTarget(); got != int64(123) {
-			t.Errorf("Headers.ReplyTarget() = %v, want %v", got, int64(123))
-		}
+
+		got := h.ReplyTarget()
+		internal.AssertEqual(t, int64(123), got)
+
 		arg[HeaderReplyTarget] = nil
-		if got := h.ReplyTarget(); got != int64(0) {
-			t.Errorf("Headers.ReplyTarget() nil = %v, want %v", got, int64(0))
-		}
+		got = h.ReplyTarget()
+		internal.AssertEqual(t, int64(0), got)
 	})
 }
 
@@ -211,13 +212,13 @@ func TestHeadersReplyTo(t *testing.T) {
 		h := &Headers{
 			Values: arg,
 		}
-		if got := h.ReplyTo(); got != "someone" {
-			t.Errorf("Headers.ReplyTo() = %v, want %v", got, "someone")
-		}
+
+		got := h.ReplyTo()
+		internal.AssertEqual(t, "someone", got)
+
 		arg[HeaderReplyTo] = nil
-		if got := h.ReplyTo(); got != "" {
-			t.Errorf("Headers.ReplyTo() nil = %v, want \"\"", got)
-		}
+		got = h.ReplyTo()
+		internal.AssertEqual(t, "", got)
 	})
 }
 
@@ -228,13 +229,13 @@ func TestHeadersVersion(t *testing.T) {
 		h := &Headers{
 			Values: arg,
 		}
-		if got := h.Version(); got != int64(1111) {
-			t.Errorf("Headers.Version() = %v, want %v", got, int64(1111))
-		}
+
+		got := h.Version()
+		internal.AssertEqual(t, int64(1111), got)
+
 		arg[HeaderSchemaVersion] = nil
-		if got := h.Version(); got != int64(0) {
-			t.Errorf("Headers.Version() nil = %v, want %v", got, int64(0))
-		}
+		got = h.Version()
+		internal.AssertEqual(t, int64(0), got)
 	})
 }
 
@@ -245,13 +246,13 @@ func TestHeadersContentType(t *testing.T) {
 		h := &Headers{
 			Values: arg,
 		}
-		if got := h.ContentType(); got != "HeaderContentType" {
-			t.Errorf("Headers.ContentType() = %v, want %v", got, "HeaderContentType")
-		}
+
+		got := h.ContentType()
+		internal.AssertEqual(t, "HeaderContentType", got)
+
 		arg[HeaderContentType] = nil
-		if got := h.ContentType(); got != "" {
-			t.Errorf("Headers.ContentType() nil = %v, want \"\"", got)
-		}
+		got = h.ContentType()
+		internal.AssertEqual(t, "", got)
 	})
 }
 
@@ -262,9 +263,9 @@ func TestHeadersGeneric(t *testing.T) {
 		h := &Headers{
 			Values: arg,
 		}
-		if got := h.Generic(HeaderContentType); !reflect.DeepEqual(got, arg[HeaderContentType]) {
-			t.Errorf("Headers.Generic() = %v, want %v", got, arg[HeaderContentType])
-		}
+
+		got := h.Generic(HeaderContentType)
+		internal.AssertEqual(t, arg[HeaderContentType], got)
 	})
 }
 
@@ -274,34 +275,33 @@ func TestHeadersMarshalJSON(t *testing.T) {
 	argErr := make(map[string]interface{})
 	someChannel := make(chan int)
 	argErr["Channel"] = someChannel
-	tests := []struct {
-		name    string
+
+	tests := map[string]struct {
 		data    map[string]interface{}
 		want    string
 		wantErr bool
 	}{
-		{
-			name:    "TestHeadersMarshalJSON ok",
+		"test_headers_marshal_JSON_ok": {
 			data:    argOk,
 			want:    "{\"content-type\":\"application/json\"}",
 			wantErr: false,
 		},
-		{
-			name:    "TestHeadersMarshalJSON error",
+		"test_headers_marshal_JSON_error": {
 			data:    argErr,
 			wantErr: true,
 		}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			h := &Headers{tt.data}
+
+	for testName, testCase := range tests {
+		t.Run(testName, func(t *testing.T) {
+			h := &Headers{testCase.data}
 			got, err := h.MarshalJSON()
-			if tt.wantErr {
+			if testCase.wantErr {
 				if err == nil {
 					t.Errorf("Headers.MarshalJSON() error must not be nil")
 				}
 			} else {
-				if string(got) != tt.want {
-					t.Errorf("Headers.MarshalJSON() = %v, want %v", string(got), tt.want)
+				if string(got) != testCase.want {
+					t.Errorf("Headers.MarshalJSON() = %v, want %v", string(got), testCase.want)
 				}
 			}
 		})
@@ -310,27 +310,26 @@ func TestHeadersMarshalJSON(t *testing.T) {
 
 func TestHeadersUnmarshalJSON(t *testing.T) {
 	ct := "application/json"
-	tests := []struct {
-		name    string
+
+	tests := map[string]struct {
 		data    string
 		wantErr bool
 	}{
-		{
-			name:    "TestHeadersUnmarshalJSON ok",
+		"test_headers_unmarshal_JSON_ok": {
 			data:    "{\"content-type\":\"application/json\"}",
 			wantErr: false,
 		},
-		{
-			name:    "TestHeadersUnmarshalJSON err",
+		"test_headers_unmarshal_JSON_err": {
 			data:    "",
 			wantErr: true,
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+
+	for testName, testCase := range tests {
+		t.Run(testName, func(t *testing.T) {
 			got := NewHeaders()
-			err := got.UnmarshalJSON([]byte(tt.data))
-			if tt.wantErr {
+			err := got.UnmarshalJSON([]byte(testCase.data))
+			if testCase.wantErr {
 				if err == nil {
 					t.Errorf("Headers.UnmarshalJSON() error must not be nil")
 				}

--- a/protocol/things/commands_test.go
+++ b/protocol/things/commands_test.go
@@ -13,9 +13,9 @@ package things
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
+	"github.com/eclipse/ditto-clients-golang/internal"
 	"github.com/eclipse/ditto-clients-golang/model"
 	"github.com/eclipse/ditto-clients-golang/protocol"
 )
@@ -43,9 +43,8 @@ func TestNewCommand(t *testing.T) {
 		Path: pathThing,
 	}
 
-	if got := NewCommand(testNamespaceID); !reflect.DeepEqual(got, want) {
-		t.Errorf("NewCommand() = %v want: %v", got, want)
-	}
+	got := NewCommand(testNamespaceID)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestCreate(t *testing.T) {
@@ -60,9 +59,8 @@ func TestCreate(t *testing.T) {
 		Payload: &model.Thing{},
 	}
 
-	if got := testCommand.Create(&model.Thing{}); !reflect.DeepEqual(got, want) {
-		t.Errorf("Command.Create() = %v want: %v", got, want)
-	}
+	got := testCommand.Create(&model.Thing{})
+	internal.AssertEqual(t, want, got)
 }
 
 func TestModify(t *testing.T) {
@@ -77,9 +75,8 @@ func TestModify(t *testing.T) {
 		Payload: &model.Feature{},
 	}
 
-	if got := testCommand.Modify(&model.Feature{}); !reflect.DeepEqual(got, want) {
-		t.Errorf("Command.Modify() = %v want: %v", got, want)
-	}
+	got := testCommand.Modify(&model.Feature{})
+	internal.AssertEqual(t, want, got)
 }
 
 func TestMerge(t *testing.T) {
@@ -94,9 +91,8 @@ func TestMerge(t *testing.T) {
 		Payload: &model.Feature{},
 	}
 
-	if got := testCommand.Merge(&model.Feature{}); !reflect.DeepEqual(got, want) {
-		t.Errorf("Command.Merge() = %v want: %v", got, want)
-	}
+	got := testCommand.Merge(&model.Feature{})
+	internal.AssertEqual(t, want, got)
 }
 
 func TestRetrieve(t *testing.T) {
@@ -167,9 +163,8 @@ func TestRetrieve(t *testing.T) {
 
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
-			if got := testCase.testCommand.Retrieve(testCase.arg...); !reflect.DeepEqual(got, testCase.want) {
-				t.Errorf("Command.Retrieve() = %v want: %v", got, testCase.want)
-			}
+			got := testCase.testCommand.Retrieve(testCase.arg...)
+			internal.AssertEqual(t, testCase.want, got)
 		})
 	}
 }
@@ -185,9 +180,8 @@ func TestDelete(t *testing.T) {
 		},
 	}
 
-	if got := testCommand.Delete(); !reflect.DeepEqual(got, want) {
-		t.Errorf("Command.Delete() = %v want: %v", got, want)
-	}
+	got := testCommand.Delete()
+	internal.AssertEqual(t, want, got)
 }
 
 func TestPolicyID(t *testing.T) {
@@ -197,9 +191,8 @@ func TestPolicyID(t *testing.T) {
 		Path: pathThingPolicyID,
 	}
 
-	if got := testEmptyCommand.PolicyID(); !reflect.DeepEqual(got, want) {
-		t.Errorf("Command.PolicyID() = %v want: %v", got, want)
-	}
+	got := testEmptyCommand.PolicyID()
+	internal.AssertEqual(t, want, got)
 }
 
 func TestDefinition(t *testing.T) {
@@ -209,9 +202,8 @@ func TestDefinition(t *testing.T) {
 		Path: pathThingDefinition,
 	}
 
-	if got := testEmptyCommand.Definition(); !reflect.DeepEqual(got, want) {
-		t.Errorf("Command.Definition() = %v want: %v", got, want)
-	}
+	got := testEmptyCommand.Definition()
+	internal.AssertEqual(t, want, got)
 }
 
 func TestAttributes(t *testing.T) {
@@ -221,9 +213,8 @@ func TestAttributes(t *testing.T) {
 		Path: pathThingAttributes,
 	}
 
-	if got := testEmptyCommand.Attributes(); !reflect.DeepEqual(got, want) {
-		t.Errorf("Command.Attributes() = %v want: %v", got, want)
-	}
+	got := testEmptyCommand.Attributes()
+	internal.AssertEqual(t, want, got)
 }
 
 func TestAttribute(t *testing.T) {
@@ -233,9 +224,8 @@ func TestAttribute(t *testing.T) {
 		Path: fmt.Sprintf(pathThingAttributeFormat, testAttributeID),
 	}
 
-	if got := testEmptyCommand.Attribute(testAttributeID); !reflect.DeepEqual(got, want) {
-		t.Errorf("Command.Attribute() = %v want: %v", got, want)
-	}
+	got := testEmptyCommand.Attribute(testAttributeID)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestFeatures(t *testing.T) {
@@ -245,9 +235,8 @@ func TestFeatures(t *testing.T) {
 		Path: pathThingFeatures,
 	}
 
-	if got := testEmptyCommand.Features(); !reflect.DeepEqual(got, want) {
-		t.Errorf("Command.Features() = %v want: %v", got, want)
-	}
+	got := testEmptyCommand.Features()
+	internal.AssertEqual(t, want, got)
 }
 
 func TestFeature(t *testing.T) {
@@ -257,9 +246,8 @@ func TestFeature(t *testing.T) {
 		Path: fmt.Sprintf(pathThingFeatureFormat, testFeatureID),
 	}
 
-	if got := testEmptyCommand.Feature(testFeatureID); !reflect.DeepEqual(got, want) {
-		t.Errorf("Command.Feature() = %v want: %v", got, want)
-	}
+	got := testEmptyCommand.Feature(testFeatureID)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestFeatureDefinition(t *testing.T) {
@@ -269,9 +257,8 @@ func TestFeatureDefinition(t *testing.T) {
 		Path: fmt.Sprintf(pathThingFeatureDefinitionFormat, testFeatureID),
 	}
 
-	if got := testEmptyCommand.FeatureDefinition(testFeatureID); !reflect.DeepEqual(got, want) {
-		t.Errorf("Command.FeatureDefinition() = %v want: %v", got, want)
-	}
+	got := testEmptyCommand.FeatureDefinition(testFeatureID)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestFeatureProperties(t *testing.T) {
@@ -281,9 +268,8 @@ func TestFeatureProperties(t *testing.T) {
 		Path: fmt.Sprintf(pathThingFeaturePropertiesFormat, testFeatureID),
 	}
 
-	if got := testEmptyCommand.FeatureProperties(testFeatureID); !reflect.DeepEqual(got, want) {
-		t.Errorf("Command.FeatureProperties() = %v want: %v", got, want)
-	}
+	got := testEmptyCommand.FeatureProperties(testFeatureID)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestFeatureProperty(t *testing.T) {
@@ -293,9 +279,8 @@ func TestFeatureProperty(t *testing.T) {
 		Path: fmt.Sprintf(pathThingFeaturePropertyFormat, testFeatureID, testPropertyID),
 	}
 
-	if got := testEmptyCommand.FeatureProperty(testFeatureID, testPropertyID); !reflect.DeepEqual(got, want) {
-		t.Errorf("Command.FeatureProperty() = %v want: %v", got, want)
-	}
+	got := testEmptyCommand.FeatureProperty(testFeatureID, testPropertyID)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestFeatureDesiredProperties(t *testing.T) {
@@ -305,9 +290,8 @@ func TestFeatureDesiredProperties(t *testing.T) {
 		Path: fmt.Sprintf(pathThingFeatureDesiredPropertiesFormat, testFeatureID),
 	}
 
-	if got := testEmptyCommand.FeatureDesiredProperties(testFeatureID); !reflect.DeepEqual(got, want) {
-		t.Errorf("Command.FeatureDesiredProperties() = %v want: %v", got, want)
-	}
+	got := testEmptyCommand.FeatureDesiredProperties(testFeatureID)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestFeatureDesiredProperty(t *testing.T) {
@@ -317,9 +301,8 @@ func TestFeatureDesiredProperty(t *testing.T) {
 		Path: fmt.Sprintf(pathThingFeatureDesiredPropertyFormat, testFeatureID, testPropertyPath),
 	}
 
-	if got := testEmptyCommand.FeatureDesiredProperty(testFeatureID, testPropertyPath); !reflect.DeepEqual(got, want) {
-		t.Errorf("Command.FeatureDesiredProperty() = %v want: %v", got, want)
-	}
+	got := testEmptyCommand.FeatureDesiredProperty(testFeatureID, testPropertyPath)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestLive(t *testing.T) {
@@ -333,9 +316,8 @@ func TestLive(t *testing.T) {
 		},
 	}
 
-	if got := testCommand.Live(); !reflect.DeepEqual(got, want) {
-		t.Errorf("Command.Live() = %v want: %v", got, want)
-	}
+	got := testCommand.Live()
+	internal.AssertEqual(t, want, got)
 }
 
 func TestTwin(t *testing.T) {
@@ -349,9 +331,8 @@ func TestTwin(t *testing.T) {
 		},
 	}
 
-	if got := testCommand.Twin(); !reflect.DeepEqual(got, want) {
-		t.Errorf("Command.Twin() = %v want: %v", got, want)
-	}
+	got := testCommand.Twin()
+	internal.AssertEqual(t, want, got)
 }
 
 func TestEnvelope(t *testing.T) {
@@ -388,9 +369,8 @@ func TestEnvelope(t *testing.T) {
 
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
-			if got := cmd.Envelope(testCase.arg...); !reflect.DeepEqual(got, testCase.want) {
-				t.Errorf("Command.Envelope() = %v want: %v", got, testCase.want)
-			}
+			got := cmd.Envelope(testCase.arg...)
+			internal.AssertEqual(t, testCase.want, got)
 		})
 	}
 }

--- a/protocol/things/events_test.go
+++ b/protocol/things/events_test.go
@@ -12,9 +12,9 @@ package things
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
+	"github.com/eclipse/ditto-clients-golang/internal"
 	"github.com/eclipse/ditto-clients-golang/model"
 	"github.com/eclipse/ditto-clients-golang/protocol"
 )
@@ -31,9 +31,8 @@ func TestNewEvent(t *testing.T) {
 		Path: pathThing,
 	}
 
-	if got := NewEvent(testNamespaceID); !reflect.DeepEqual(got, want) {
-		t.Errorf("NewEvent() = %v want: %v", got, want)
-	}
+	got := NewEvent(testNamespaceID)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestCreated(t *testing.T) {
@@ -48,9 +47,8 @@ func TestCreated(t *testing.T) {
 		Payload: &model.Thing{},
 	}
 
-	if got := testEvent.Created(&model.Thing{}); !reflect.DeepEqual(got, want) {
-		t.Errorf("Event.Created() = %v want: %v", got, want)
-	}
+	got := testEvent.Created(&model.Thing{})
+	internal.AssertEqual(t, want, got)
 }
 
 func TestModified(t *testing.T) {
@@ -65,9 +63,8 @@ func TestModified(t *testing.T) {
 		Payload: &model.Feature{},
 	}
 
-	if got := testEvent.Modified(&model.Feature{}); !reflect.DeepEqual(got, want) {
-		t.Errorf("Event.Modified() = %v want: %v", got, want)
-	}
+	got := testEvent.Modified(&model.Feature{})
+	internal.AssertEqual(t, want, got)
 }
 
 func TestMerged(t *testing.T) {
@@ -82,9 +79,8 @@ func TestMerged(t *testing.T) {
 		Payload: &model.Feature{},
 	}
 
-	if got := testEvent.Merged(&model.Feature{}); !reflect.DeepEqual(got, want) {
-		t.Errorf("Event.Merged() = %v want: %v", got, want)
-	}
+	got := testEvent.Merged(&model.Feature{})
+	internal.AssertEqual(t, want, got)
 }
 
 func TestDeleted(t *testing.T) {
@@ -98,9 +94,8 @@ func TestDeleted(t *testing.T) {
 		},
 	}
 
-	if got := testEvent.Deleted(); !reflect.DeepEqual(got, want) {
-		t.Errorf("Event.Deleted() = %v want: %v", got, want)
-	}
+	got := testEvent.Deleted()
+	internal.AssertEqual(t, want, got)
 }
 
 func TestEventPolicyID(t *testing.T) {
@@ -110,9 +105,8 @@ func TestEventPolicyID(t *testing.T) {
 		Path: pathThingPolicyID,
 	}
 
-	if got := testEmptyEvent.PolicyID(); !reflect.DeepEqual(got, want) {
-		t.Errorf("Event.PolicyID() = %v want: %v", got, want)
-	}
+	got := testEmptyEvent.PolicyID()
+	internal.AssertEqual(t, want, got)
 }
 
 func TestEventDefinition(t *testing.T) {
@@ -122,9 +116,8 @@ func TestEventDefinition(t *testing.T) {
 		Path: pathThingDefinition,
 	}
 
-	if got := testEmptyEvent.Definition(); !reflect.DeepEqual(got, want) {
-		t.Errorf("Event.Definition() = %v want: %v", got, want)
-	}
+	got := testEmptyEvent.Definition()
+	internal.AssertEqual(t, want, got)
 }
 
 func TestEventAttributes(t *testing.T) {
@@ -134,9 +127,8 @@ func TestEventAttributes(t *testing.T) {
 		Path: pathThingAttributes,
 	}
 
-	if got := testEmptyEvent.Attributes(); !reflect.DeepEqual(got, want) {
-		t.Errorf("Event.Attributes() = %v want: %v", got, want)
-	}
+	got := testEmptyEvent.Attributes()
+	internal.AssertEqual(t, want, got)
 }
 
 func TestEventAttribute(t *testing.T) {
@@ -146,9 +138,8 @@ func TestEventAttribute(t *testing.T) {
 		Path: fmt.Sprintf(pathThingAttributeFormat, testAttributeID),
 	}
 
-	if got := testEmptyEvent.Attribute(testAttributeID); !reflect.DeepEqual(got, want) {
-		t.Errorf("Event.Attribute() = %v want: %v", got, want)
-	}
+	got := testEmptyEvent.Attribute(testAttributeID)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestEventFeatures(t *testing.T) {
@@ -158,9 +149,8 @@ func TestEventFeatures(t *testing.T) {
 		Path: pathThingFeatures,
 	}
 
-	if got := testEmptyEvent.Features(); !reflect.DeepEqual(got, want) {
-		t.Errorf("Event.Features() = %v want: %v", got, want)
-	}
+	got := testEmptyEvent.Features()
+	internal.AssertEqual(t, want, got)
 }
 
 func TestEventFeature(t *testing.T) {
@@ -170,9 +160,8 @@ func TestEventFeature(t *testing.T) {
 		Path: fmt.Sprintf(pathThingFeatureFormat, testFeatureID),
 	}
 
-	if got := testEmptyEvent.Feature(testFeatureID); !reflect.DeepEqual(got, want) {
-		t.Errorf("Event.Feature() = %v want: %v", got, want)
-	}
+	got := testEmptyEvent.Feature(testFeatureID)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestEventFeatureDefinition(t *testing.T) {
@@ -182,9 +171,8 @@ func TestEventFeatureDefinition(t *testing.T) {
 		Path: fmt.Sprintf(pathThingFeatureDefinitionFormat, testFeatureID),
 	}
 
-	if got := testEmptyEvent.FeatureDefinition(testFeatureID); !reflect.DeepEqual(got, want) {
-		t.Errorf("Event.FeatureDefinition() = %v want: %v", got, want)
-	}
+	got := testEmptyEvent.FeatureDefinition(testFeatureID)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestEventFeatureProperties(t *testing.T) {
@@ -194,9 +182,8 @@ func TestEventFeatureProperties(t *testing.T) {
 		Path: fmt.Sprintf(pathThingFeaturePropertiesFormat, testFeatureID),
 	}
 
-	if got := testEmptyEvent.FeatureProperties(testFeatureID); !reflect.DeepEqual(got, want) {
-		t.Errorf("Event.FeatureProperties() = %v want: %v", got, want)
-	}
+	got := testEmptyEvent.FeatureProperties(testFeatureID)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestEventFeatureProperty(t *testing.T) {
@@ -206,9 +193,8 @@ func TestEventFeatureProperty(t *testing.T) {
 		Path: fmt.Sprintf(pathThingFeaturePropertyFormat, testFeatureID, testPropertyID),
 	}
 
-	if got := testEmptyEvent.FeatureProperty(testFeatureID, testPropertyID); !reflect.DeepEqual(got, want) {
-		t.Errorf("Event.FeatureProperty() = %v want: %v", got, want)
-	}
+	got := testEmptyEvent.FeatureProperty(testFeatureID, testPropertyID)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestEventFeatureDesiredProperties(t *testing.T) {
@@ -218,9 +204,8 @@ func TestEventFeatureDesiredProperties(t *testing.T) {
 		Path: fmt.Sprintf(pathThingFeatureDesiredPropertiesFormat, testFeatureID),
 	}
 
-	if got := testEmptyEvent.FeatureDesiredProperties(testFeatureID); !reflect.DeepEqual(got, want) {
-		t.Errorf("Event.FeatureDesiredProperties() = %v want: %v", got, want)
-	}
+	got := testEmptyEvent.FeatureDesiredProperties(testFeatureID)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestEventFeatureDesiredProperty(t *testing.T) {
@@ -230,9 +215,8 @@ func TestEventFeatureDesiredProperty(t *testing.T) {
 		Path: fmt.Sprintf(pathThingFeatureDesiredPropertyFormat, testFeatureID, testPropertyPath),
 	}
 
-	if got := testEmptyEvent.FeatureDesiredProperty(testFeatureID, testPropertyPath); !reflect.DeepEqual(got, want) {
-		t.Errorf("Event.FeatureDesiredProperty() = %v want: %v", got, want)
-	}
+	got := testEmptyEvent.FeatureDesiredProperty(testFeatureID, testPropertyPath)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestEventLive(t *testing.T) {
@@ -246,9 +230,8 @@ func TestEventLive(t *testing.T) {
 		},
 	}
 
-	if got := testEvent.Live(); !reflect.DeepEqual(got, want) {
-		t.Errorf("Event.Live() = %v want: %v", got, want)
-	}
+	got := testEvent.Live()
+	internal.AssertEqual(t, want, got)
 }
 
 func TestEventTwin(t *testing.T) {
@@ -262,9 +245,8 @@ func TestEventTwin(t *testing.T) {
 		},
 	}
 
-	if got := testEvent.Twin(); !reflect.DeepEqual(got, want) {
-		t.Errorf("Event.Twin() = %v want: %v", got, want)
-	}
+	got := testEvent.Twin()
+	internal.AssertEqual(t, want, got)
 }
 
 func TestEventEnvelope(t *testing.T) {
@@ -301,9 +283,8 @@ func TestEventEnvelope(t *testing.T) {
 
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
-			if got := event.Envelope(testCase.arg...); !reflect.DeepEqual(got, testCase.want) {
-				t.Errorf("Event.Envelope() = %v want: %v", got, testCase.want)
-			}
+			got := event.Envelope(testCase.arg...)
+			internal.AssertEqual(t, testCase.want, got)
 		})
 	}
 }

--- a/protocol/things/messages_test.go
+++ b/protocol/things/messages_test.go
@@ -12,9 +12,9 @@ package things
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
+	"github.com/eclipse/ditto-clients-golang/internal"
 	"github.com/eclipse/ditto-clients-golang/model"
 	"github.com/eclipse/ditto-clients-golang/protocol"
 )
@@ -31,9 +31,8 @@ func TestNewMessage(t *testing.T) {
 		AddressedPartOfThing: "",
 	}
 
-	if got := NewMessage(testNamespaceID); !reflect.DeepEqual(got, want) {
-		t.Errorf("NewMessage() = %v want: %v", got, want)
-	}
+	got := NewMessage(testNamespaceID)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestInbox(t *testing.T) {
@@ -51,9 +50,8 @@ func TestInbox(t *testing.T) {
 		Mailbox: inbox,
 	}
 
-	if got := testMessage.Inbox(arg); !reflect.DeepEqual(got, want) {
-		t.Errorf("Message.Inbox() = %v want: %v", got, want)
-	}
+	got := testMessage.Inbox(arg)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestOutbox(t *testing.T) {
@@ -71,9 +69,8 @@ func TestOutbox(t *testing.T) {
 		Mailbox: outbox,
 	}
 
-	if got := testMessage.Outbox(arg); !reflect.DeepEqual(got, want) {
-		t.Errorf("Message.Outbox() = %v want: %v", got, want)
-	}
+	got := testMessage.Outbox(arg)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestWithPayload(t *testing.T) {
@@ -85,9 +82,8 @@ func TestWithPayload(t *testing.T) {
 		Payload: arg,
 	}
 
-	if got := testMessage.WithPayload(arg); !reflect.DeepEqual(got, want) {
-		t.Errorf("Message.WithPayload() = %v want: %v", got, want)
-	}
+	got := testMessage.WithPayload(arg)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestMessageFeature(t *testing.T) {
@@ -97,9 +93,8 @@ func TestMessageFeature(t *testing.T) {
 		AddressedPartOfThing: fmt.Sprintf(pathThingFeatureFormat, testFeatureID),
 	}
 
-	if got := testMessage.Feature(testFeatureID); !reflect.DeepEqual(got, want) {
-		t.Errorf("Message.Feature() = %v want: %v", got, want)
-	}
+	got := testMessage.Feature(testFeatureID)
+	internal.AssertEqual(t, want, got)
 }
 
 func TestMessageEnvelope(t *testing.T) {
@@ -136,9 +131,8 @@ func TestMessageEnvelope(t *testing.T) {
 
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
-			if got := msg.Envelope(testCase.arg...); !reflect.DeepEqual(got, testCase.want) {
-				t.Errorf("Event.Envelope() = %v want: %v", got, testCase.want)
-			}
+			got := msg.Envelope(testCase.arg...)
+			internal.AssertEqual(t, testCase.want, got)
 		})
 	}
 }

--- a/protocol/topic_test.go
+++ b/protocol/topic_test.go
@@ -12,18 +12,18 @@
 package protocol
 
 import (
-	"reflect"
+	"errors"
 	"testing"
+
+	"github.com/eclipse/ditto-clients-golang/internal"
 )
 
 func TestTopicString(t *testing.T) {
-	tests := []struct {
-		name  string
+	tests := map[string]struct {
 		topic Topic
 		want  string
 	}{
-		{
-			name: "TestTopicString GroupThings",
+		"test_topic_string_group_things": {
 			topic: Topic{
 				Namespace:  "namespace",
 				EntityName: "entity_name",
@@ -35,8 +35,7 @@ func TestTopicString(t *testing.T) {
 			want: "namespace/entity_name/" + string(GroupThings) + "/" + string(ChannelTwin) + "/" +
 				string(CriterionMessages) + "/" + string(ActionSubscribe),
 		},
-		{
-			name: "TestTopicString GroupPolicies",
+		"test_topic_string_group_policies": {
 			topic: Topic{
 				Namespace:  "namespace",
 				EntityName: "entity_name",
@@ -48,8 +47,7 @@ func TestTopicString(t *testing.T) {
 			want: "namespace/entity_name/" + string(GroupPolicies) + "/" +
 				string(CriterionCommands) + "/" + string(ActionCreate),
 		},
-		{
-			name: "TestTopicString empty",
+		"test_topic_string_empty": {
 			topic: Topic{
 				Namespace:  "namespace",
 				EntityName: "entity_name",
@@ -59,14 +57,13 @@ func TestTopicString(t *testing.T) {
 				Action:     ActionCreate,
 			},
 			want: "",
-		}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := tt.topic.String()
-			if got != tt.want {
-				t.Errorf("Topic.String() = %v, want %v", got, tt.want)
-			}
+		},
+	}
 
+	for testName, testCase := range tests {
+		t.Run(testName, func(t *testing.T) {
+			got := testCase.topic.String()
+			internal.AssertEqual(t, testCase.want, got)
 		})
 	}
 }
@@ -85,86 +82,83 @@ func TestTopicMarshalJSON(t *testing.T) {
 		grp := "\"namespace/entity_name/" + string(GroupThings) +
 			"/" + string(ChannelTwin) + "/" + string(CriterionMessages) + "/" +
 			string(ActionSubscribe) + "\""
-		if err != nil {
-			t.Errorf("Topic.MarshalJSON() error = %v", err)
-		}
-		if !reflect.DeepEqual(grp, string(got)) {
-			t.Errorf("Topic.MarshalJSON() want = %v , got %v", grp, string(got))
-		}
+
+		internal.AssertNil(t, err)
+		internal.AssertEqual(t, grp, string(got))
 	})
 }
 
 func TestTopicUnmarshalJSON(t *testing.T) {
-
-	tests := []struct {
-		name                  string
+	tests := map[string]struct {
 		data                  string
 		wantErr               bool
 		onlyForUnmarshalError bool
 	}{
-		{
-			name: "TestTopicUnmarshalJSON GroupThings",
+		"test_topic_unmarshal_JSON_group_things": {
 			data: "namespace/entity_name/" +
-				string(GroupThings) + "/" + string(ChannelTwin) + "/" + string(CriterionMessages) + "/" +
+				string(GroupThings) + "/" +
+				string(ChannelTwin) + "/" +
+				string(CriterionMessages) + "/" +
 				string(ActionSubscribe),
 			wantErr:               false,
 			onlyForUnmarshalError: false,
 		},
-		{
-			name: "TestTopicUnmarshalJSON GroupPolicies",
+		"test_topic_unmarshal_JSON_group_policies": {
 			data: "namespace/entity_name/" +
-				string(GroupPolicies) + "/" + string(CriterionCommands) + "/" + string(ActionCreate),
+				string(GroupPolicies) + "/" +
+				string(CriterionCommands) + "/" +
+				string(ActionCreate),
 			wantErr:               false,
 			onlyForUnmarshalError: false,
 		},
-		{
-			name:                  "TestTopicUnmarshalJSON for insufficient elements",
+		"test_topic_unmarshal_JSON_insufficient_elements": {
 			data:                  "///",
 			wantErr:               true,
 			onlyForUnmarshalError: false,
 		},
-		{
-			name: "TestTopicUnmarshalJSON GroupThings for missing channel for things",
+		"test_topic_unmarshal_JSON_group_things_missing_channel_for_things": {
 			data: "namespace/entity_name/" +
-				string(GroupThings) + "/" /*+ string(ChannelTwin) + "/"*/ + string(CriterionMessages) + "/" +
+				string(GroupThings) + "/" /*+ string(ChannelTwin) + "/"*/ +
+				string(CriterionMessages) + "/" +
 				string(ActionSubscribe),
 			wantErr:               true,
 			onlyForUnmarshalError: false,
 		},
-		{
-			name: "TestTopicUnmarshalJSON GroupThings insufficient elements for things",
+		"test_topic_unmarshal_JSON_group_things_insufficient_elements_for_things": {
 			data: "namespace/entity_name/" +
-				string(GroupThings) + "/" + string(ChannelTwin) + "/" + string(CriterionMessages),
+				string(GroupThings) + "/" +
+				string(ChannelTwin) + "/" +
+				string(CriterionMessages),
 			wantErr:               true,
 			onlyForUnmarshalError: false,
 		},
-		{
-			name:                  "TestTopicUnmarshalJSON topic must be empty",
+		"test_topic_unmarshal_JSON_topic_must_empty": {
 			data:                  "/////",
 			wantErr:               true,
 			onlyForUnmarshalError: false,
 		},
-		{
-			name:                  "TestTopicUnmarshalJSON no data",
+		"test_topic_unmarshal_JSON_no_data": {
 			data:                  "",
 			wantErr:               true,
 			onlyForUnmarshalError: false,
 		},
-		{
-			name: "TestTopicUnmarshalJSON only for internal error",
+		"test_topic_unmarshal_JSON_only_for_internal_error": {
 			data: "namespace/entity_name/" +
-				string(GroupThings) + "/" + string(ChannelTwin) + "/" + string(CriterionMessages) + "/" +
+				string(GroupThings) + "/" +
+				string(ChannelTwin) + "/" +
+				string(CriterionMessages) + "/" +
 				string(ActionSubscribe),
 			wantErr:               true,
 			onlyForUnmarshalError: true,
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+
+	for testName, testCase := range tests {
+		t.Run(testName, func(t *testing.T) {
 			topic := Topic{}
 			defer func() {
 				if r := recover(); r != nil {
-					if tt.wantErr {
+					if testCase.wantErr {
 						t.Logf("Topic.UnmarshalJSON() %v", r)
 					} else {
 						t.Errorf("Topic.UnmarshalJSON() unexpected error %v", r)
@@ -172,13 +166,13 @@ func TestTopicUnmarshalJSON(t *testing.T) {
 				}
 			}()
 			var err error
-			if tt.onlyForUnmarshalError {
+			if testCase.onlyForUnmarshalError {
 				err = topic.UnmarshalJSON([]byte(nil))
 			} else {
-				err = topic.UnmarshalJSON([]byte("\"" + tt.data + "\""))
+				err = topic.UnmarshalJSON([]byte("\"" + testCase.data + "\""))
 			}
 			if err != nil {
-				if tt.wantErr {
+				if testCase.wantErr {
 					t.Logf("Topic.UnmarshalJSON() error = %v", err)
 					return
 				} else {
@@ -187,7 +181,7 @@ func TestTopicUnmarshalJSON(t *testing.T) {
 				}
 			}
 			if topic.String() == "" {
-				if tt.wantErr {
+				if testCase.wantErr {
 					t.Logf("Topic.UnmarshalJSON() topic is empty")
 					return
 				} else {
@@ -195,10 +189,73 @@ func TestTopicUnmarshalJSON(t *testing.T) {
 					return
 				}
 			}
-			if topic.String() != tt.data {
-				t.Errorf("Topic.UnmarshalJSON() want = %v, got %v", topic.String(), tt.data)
+			if topic.String() != testCase.data {
+				t.Errorf("Topic.UnmarshalJSON() want = %v, got %v", topic.String(), testCase.data)
 				return
 			}
+		})
+	}
+}
+
+func TestTopicNamespace(t *testing.T) {
+	var (
+		testValidNamespace    = "test.namespace"
+		testInvalidNamespace  = "test:namespace"
+		testValidEntityName   = "test.name"
+		testInvalidEntityName = "test§name"
+	)
+
+	tests := map[string]struct {
+		data       string
+		namespace  string
+		entityName string
+		wantErr    error
+	}{
+		"test_topic_unmarshal_JSON_valid_namespace_entity_name": {
+			data:       testValidNamespace + "/" + testValidEntityName + "/things/twin/retrieve",
+			namespace:  testValidNamespace,
+			entityName: testValidEntityName,
+			wantErr:    nil,
+		},
+		"test_topic_unmarshal_JSON_empty_namespace_valid_entity_name": {
+			data:       TopicPlaceholder + "/" + testValidEntityName + "/things/twin/retrieve",
+			namespace:  TopicPlaceholder,
+			entityName: testValidEntityName,
+			wantErr:    nil,
+		},
+		"test_topic_unmarshal_JSON_valid_namespace_empty_entity_name": {
+			data:       testValidNamespace + "/" + TopicPlaceholder + "/things/twin/retrieve",
+			namespace:  testValidNamespace,
+			entityName: TopicPlaceholder,
+			wantErr:    nil,
+		},
+		"test_topic_unmarshal_JSON_empty_namespace_empty_entity_name": {
+			data:       TopicPlaceholder + "/" + TopicPlaceholder + "/things/twin/retrieve",
+			namespace:  TopicPlaceholder,
+			entityName: TopicPlaceholder,
+			wantErr:    nil,
+		},
+		"test_topic_unmarshal_JSON_invalid_namespace": {
+			data:       testInvalidNamespace + "/" + testValidEntityName + "/things/twin/retrieve",
+			namespace:  "",
+			entityName: "",
+			wantErr:    errors.New("invalid topic namespaced ID, namespace: " + testInvalidNamespace + ", entity name: " + testValidEntityName),
+		},
+		"test_topic_unmarshal_JSON_invalid_entity_name": {
+			data:       testValidNamespace + "/" + testInvalidEntityName + "/things/twin/retrieve",
+			namespace:  "",
+			entityName: "",
+			wantErr:    errors.New("invalid topic namespaced ID, namespace: " + testValidNamespace + ", entity name: " + testInvalidEntityName),
+		},
+	}
+
+	for testName, testCase := range tests {
+		t.Run(testName, func(t *testing.T) {
+			topic := Topic{}
+			err := topic.UnmarshalJSON([]byte("\"" + testCase.data + "\""))
+			internal.AssertError(t, testCase.wantErr, err)
+			internal.AssertEqual(t, testCase.namespace, topic.Namespace)
+			internal.AssertEqual(t, testCase.entityName, topic.EntityName)
 		})
 	}
 }
@@ -207,9 +264,8 @@ func TestTopicWithNamespace(t *testing.T) {
 	t.Run("TestTopicWithNamespace", func(t *testing.T) {
 		arg := "namespace"
 		topic := Topic{}
-		if got := topic.WithNamespace(arg); !reflect.DeepEqual(got.Namespace, arg) {
-			t.Errorf("Topic.WithNamespace() = %v, want %v", got.Namespace, arg)
-		}
+		got := topic.WithNamespace(arg)
+		internal.AssertEqual(t, arg, got.Namespace)
 	})
 }
 
@@ -217,9 +273,8 @@ func TestTopicWithEntityName(t *testing.T) {
 	t.Run("TestTopicWithEntityName", func(t *testing.T) {
 		arg := "EntityName"
 		topic := Topic{}
-		if got := topic.WithEntityName(arg); !reflect.DeepEqual(got.EntityName, arg) {
-			t.Errorf("Topic.WithEntityName() = %v, want %v", got.EntityName, arg)
-		}
+		got := topic.WithEntityName(arg)
+		internal.AssertEqual(t, arg, got.EntityName)
 	})
 }
 
@@ -227,9 +282,8 @@ func TestTopicWithGroup(t *testing.T) {
 	t.Run("TestTopicWithGroup", func(t *testing.T) {
 		arg := GroupThings
 		topic := Topic{}
-		if got := topic.WithGroup(arg); !reflect.DeepEqual(got.Group, arg) {
-			t.Errorf("Topic.WithGroup() = %v, want %v", got.Group, arg)
-		}
+		got := topic.WithGroup(arg)
+		internal.AssertEqual(t, arg, got.Group)
 	})
 }
 
@@ -237,9 +291,8 @@ func TestTopicWithChannel(t *testing.T) {
 	t.Run("TestTopicWithChannel", func(t *testing.T) {
 		arg := ChannelTwin
 		topic := Topic{}
-		if got := topic.WithChannel(arg); !reflect.DeepEqual(got.Channel, arg) {
-			t.Errorf("Topic.WithChannel() = %v, want %v", got.Channel, arg)
-		}
+		got := topic.WithChannel(arg)
+		internal.AssertEqual(t, arg, got.Channel)
 	})
 }
 
@@ -247,9 +300,8 @@ func TestTopicWithCriterion(t *testing.T) {
 	t.Run("TestTopicWithCriterion", func(t *testing.T) {
 		arg := CriterionMessages
 		topic := Topic{}
-		if got := topic.WithCriterion(arg); !reflect.DeepEqual(got.Criterion, arg) {
-			t.Errorf("Topic.WithCriterion() = %v, want %v", got.Criterion, arg)
-		}
+		got := topic.WithCriterion(arg)
+		internal.AssertEqual(t, arg, got.Criterion)
 	})
 }
 
@@ -257,8 +309,7 @@ func TestTopicWithAction(t *testing.T) {
 	t.Run("TestTopicWithAction", func(t *testing.T) {
 		arg := ActionSubscribe
 		topic := Topic{}
-		if got := topic.WithAction(arg); !reflect.DeepEqual(got.Action, arg) {
-			t.Errorf("Topic.WithAction() = %v, want %v", got.Action, arg)
-		}
+		got := topic.WithAction(arg)
+		internal.AssertEqual(t, arg, got.Action)
 	})
 }


### PR DESCRIPTION
- Missing Topic NamespacedID validation on Envelope unmarshalling
- Refactor the testcase to use assertion util
- Use a map instead of array for test tables in Unit TCs

Signed-off-by: Antonia Trifonova antonia.trifonova@bosch.io