### PR TITLE
Filter out insecure cipher suites in TLS configuration

### DIFF
--- a/client.go
+++ b/client.go
@@ -13,10 +13,11 @@ package ditto
 
 import (
 	"errors"
+	"sync"
+
 	"github.com/eclipse/ditto-clients-golang/protocol"
 	MQTT "github.com/eclipse/paho.mqtt.golang"
 	"github.com/google/uuid"
-	"sync"
 )
 
 var (
@@ -47,6 +48,10 @@ type Client struct {
 
 // NewClient creates a new Client instance with the provided Configuration.
 func NewClient(cfg *Configuration) *Client {
+	if cfg.tlsConfig != nil {
+		initCipherSutesMinVersion(cfg.tlsConfig)
+	}
+
 	client := &Client{
 		cfg:      cfg,
 		handlers: map[string]Handler{},

--- a/client_config.go
+++ b/client_config.go
@@ -189,5 +189,6 @@ func (cfg *Configuration) WithConnectionLostHandler(connectionLostHandler Connec
 // WithTLSConfig sets the TLS configuration to be used by the Client's underlying connection.
 func (cfg *Configuration) WithTLSConfig(tlsConfig *tls.Config) *Configuration {
 	cfg.tlsConfig = tlsConfig
+	initCipherSutesMinVersion(cfg.tlsConfig)
 	return cfg
 }

--- a/utils.go
+++ b/utils.go
@@ -12,13 +12,15 @@
 package ditto
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/eclipse/ditto-clients-golang/protocol"
 	"reflect"
 	"regexp"
 	"runtime"
+
+	"github.com/eclipse/ditto-clients-golang/protocol"
 )
 
 var regexHonoMQTTTopicRequest, _ = regexp.Compile("^command///req/([^/]+)/([^/]+)$")
@@ -70,4 +72,22 @@ func validateConfiguration(cfg *Configuration) error {
 		return errors.New("TLS configuration is not expected when using external MQTT client")
 	}
 	return nil
+}
+
+func supportedCipherSuites() []uint16 {
+	cs := tls.CipherSuites()
+	cid := make([]uint16, len(cs))
+	for i := range cs {
+		cid[i] = cs[i].ID
+	}
+	return cid
+}
+
+func initCipherSutesMinVersion(tlsConfig *tls.Config) {
+	if tlsConfig.CipherSuites == nil || len(tlsConfig.CipherSuites) == 0 {
+		tlsConfig.CipherSuites = supportedCipherSuites()
+	}
+	if tlsConfig.MinVersion == 0 {
+		tlsConfig.MinVersion = tls.VersionTLS12
+	}
 }


### PR DESCRIPTION
For legacy reasons Go uses by default both secure and insecure ciphers. The insecure are not used unless the Hub has nothing else to offer, which is not the case, but because of various regulations and penetration tests results we need to filter them out.
We however do not want to mess with the crypto package definitions and include or exclude specific ciphers.
Therefore we have to take the list of secure ones from the crypto package and pass them to TLS configuration unmodified.

Signed-off-by: Antonia Trifonova antonia.trifonova@bosch.io