### PR TITLE
No easy way to create a headers copy

### DIFF
--- a/protocol/headers_opts.go
+++ b/protocol/headers_opts.go
@@ -24,14 +24,31 @@ func applyOptsHeader(headers *Headers, opts ...HeaderOpt) error {
 	return nil
 }
 
-// NewHeaders returns a new Headers instance.
-func NewHeaders(opts ...HeaderOpt) *Headers {
+func applyHeaderValues(values map[string]interface{}, opts ...HeaderOpt) *Headers {
 	res := &Headers{}
-	res.Values = make(map[string]interface{})
+	if values != nil {
+		res.Values = values
+	} else {
+		res.Values = make(map[string]interface{})
+	}
 	if err := applyOptsHeader(res, opts...); err != nil {
 		return nil
 	}
 	return res
+}
+
+// NewHeaders returns a new Headers instance.
+func NewHeaders(opts ...HeaderOpt) *Headers {
+	return applyHeaderValues(nil, opts...)
+}
+
+// NewHeadersFrom returns a new Headers instance using the provided header.
+func NewHeadersFrom(orig *Headers, opts ...HeaderOpt) *Headers {
+	if orig == nil {
+		return NewHeaders(opts...)
+	}
+	return applyHeaderValues(orig.Values, opts...)
+
 }
 
 // WithCorrelationID sets the 'correlation-id' header value.

--- a/protocol/headers_opts.go
+++ b/protocol/headers_opts.go
@@ -24,22 +24,14 @@ func applyOptsHeader(headers *Headers, opts ...HeaderOpt) error {
 	return nil
 }
 
-func applyHeaderValues(values map[string]interface{}, opts ...HeaderOpt) *Headers {
+// NewHeaders returns a new Headers instance.
+func NewHeaders(opts ...HeaderOpt) *Headers {
 	res := &Headers{}
-	if values != nil {
-		res.Values = values
-	} else {
-		res.Values = make(map[string]interface{})
-	}
+	res.Values = make(map[string]interface{})
 	if err := applyOptsHeader(res, opts...); err != nil {
 		return nil
 	}
 	return res
-}
-
-// NewHeaders returns a new Headers instance.
-func NewHeaders(opts ...HeaderOpt) *Headers {
-	return applyHeaderValues(nil, opts...)
 }
 
 // NewHeadersFrom returns a new Headers instance using the provided header.
@@ -47,8 +39,16 @@ func NewHeadersFrom(orig *Headers, opts ...HeaderOpt) *Headers {
 	if orig == nil {
 		return NewHeaders(opts...)
 	}
-	return applyHeaderValues(orig.Values, opts...)
-
+	res := &Headers{
+		Values: make(map[string]interface{}),
+	}
+	for key, value := range orig.Values {
+		res.Values[key] = value
+	}
+	if err := applyOptsHeader(res, opts...); err != nil {
+		return nil
+	}
+	return res
 }
 
 // WithCorrelationID sets the 'correlation-id' header value.


### PR DESCRIPTION
Used for scenarios when the incoming message headers should be changed (create a copy with some modification in addition).
Provide in addition copy constructor with two arguments - original Headers and HeaderOpt

Signed-off-by: Antonia Trifonova antonia.trifonova@bosch.io