### PR TITLE
Fix regex for Topic entity

### DIFF
--- a/protocol/topic.go
+++ b/protocol/topic.go
@@ -16,7 +16,6 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-	"strings"
 
 	"github.com/eclipse/ditto-clients-golang/model"
 )
@@ -134,10 +133,8 @@ func (topic *Topic) UnmarshalJSON(data []byte) error {
 	}
 
 	elements := matches[0]
-	index := 1
-	ns := elements[index]
-	index++
-	name := elements[index]
+	ns := elements[1]
+	name := elements[2]
 
 	if err := validateNamespacedID(ns, name); err != nil {
 		return err
@@ -145,27 +142,19 @@ func (topic *Topic) UnmarshalJSON(data []byte) error {
 
 	topic.Namespace = ns
 	topic.EntityName = name
-	index++
-	topic.Group = TopicGroup(elements[index])
-	index++
+	topic.Group = TopicGroup(elements[3])
 
 	switch topic.Group {
 	case GroupThings:
-		topic.Channel = TopicChannel(elements[index])
-		index++
+		topic.Channel = TopicChannel(elements[4])
+		topic.Criterion = TopicCriterion(elements[5])
+		topic.Action = TopicAction(elements[7])
 	default:
 		// skip channel - not supported for policies group
 		topic.Channel = ""
+		topic.Criterion = TopicCriterion(elements[4])
+		topic.Action = TopicAction(elements[5])
 	}
-
-	topic.Criterion = TopicCriterion(elements[index])
-	index++
-
-	if strings.HasPrefix(elements[index], "/") {
-		index++
-	}
-
-	topic.Action = TopicAction(elements[index])
 
 	return nil
 }

--- a/protocol/topic.go
+++ b/protocol/topic.go
@@ -89,7 +89,7 @@ const (
 )
 
 var regexFiveElementTopic = regexp.MustCompile("^([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/]+)$")
-var regexSixElementTopic = regexp.MustCompile("^([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/]+)$")
+var regexSixElementTopic = regexp.MustCompile("^([^/]+)/([^/]+)/([^/]+)/([^/]+)/([^/]+)/(.*)$")
 
 // Topic represents the Ditto protocol's Topic entity. It's represented in the form of:
 // <namespace>/<entity-name>/<group>/<channel>/<criterion>/<action>.
@@ -157,7 +157,12 @@ func (topic *Topic) UnmarshalJSON(data []byte) error {
 	topic.Criterion = TopicCriterion(elements[index])
 	index++
 	if index < len(elements) {
-		topic.Action = TopicAction(elements[index])
+		if topic.Criterion == CriterionMessages {
+			i := strings.Index(v, elements[index])
+			topic.Action = TopicAction(v[i:])
+		} else {
+			topic.Action = TopicAction(elements[index])
+		}
 	} else {
 		topic.Action = ""
 	}

--- a/protocol/topic_test.go
+++ b/protocol/topic_test.go
@@ -151,6 +151,33 @@ func TestTopicUnmarshalJSON(t *testing.T) {
 			wantErr:               true,
 			onlyForUnmarshalError: true,
 		},
+		"test_topic_unmarshal_JSON_set_configuration": {
+			data: "namespace/entity_name/" +
+				string(GroupThings) + "/" +
+				string(ChannelLive) + "/" +
+				string(CriterionMessages) + "/" +
+				"$set.configuration/name",
+			wantErr:               false,
+			onlyForUnmarshalError: false,
+		},
+		"test_topic_unmarshal_JSON_refresh_property": {
+			data: "namespace/entity_name/" +
+				string(GroupThings) + "/" +
+				string(ChannelLive) + "/" +
+				string(CriterionMessages) + "/" +
+				"$refresh.name",
+			wantErr:               false,
+			onlyForUnmarshalError: false,
+		},
+		"test_topic_unmarshal_JSON_refresh_action": {
+			data: "namespace/entity_name/" +
+				string(GroupThings) + "/" +
+				string(ChannelLive) + "/" +
+				string(CriterionMessages) + "/" +
+				"$refresh",
+			wantErr:               false,
+			onlyForUnmarshalError: false,
+		},
 	}
 
 	for testName, testCase := range tests {

--- a/protocol/topic_test.go
+++ b/protocol/topic_test.go
@@ -13,6 +13,7 @@ package protocol
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/eclipse/ditto-clients-golang/internal"
@@ -32,8 +33,11 @@ func TestTopicString(t *testing.T) {
 				Criterion:  CriterionMessages,
 				Action:     ActionSubscribe,
 			},
-			want: "namespace/entity_name/" + string(GroupThings) + "/" + string(ChannelTwin) + "/" +
-				string(CriterionMessages) + "/" + string(ActionSubscribe),
+			want: "namespace/entity_name/" +
+				string(GroupThings) + "/" +
+				string(ChannelTwin) + "/" +
+				string(CriterionMessages) + "/" +
+				string(ActionSubscribe),
 		},
 		"test_topic_string_group_policies": {
 			topic: Topic{
@@ -44,8 +48,10 @@ func TestTopicString(t *testing.T) {
 				Criterion:  CriterionCommands,
 				Action:     ActionCreate,
 			},
-			want: "namespace/entity_name/" + string(GroupPolicies) + "/" +
-				string(CriterionCommands) + "/" + string(ActionCreate),
+			want: "namespace/entity_name/" +
+				string(GroupPolicies) + "/" +
+				string(CriterionCommands) + "/" +
+				string(ActionCreate),
 		},
 		"test_topic_string_empty": {
 			topic: Topic{
@@ -70,163 +76,131 @@ func TestTopicString(t *testing.T) {
 
 func TestTopicMarshalJSON(t *testing.T) {
 	t.Run("TestTopicMarshalJSON", func(t *testing.T) {
-		topic := Topic{
-			Namespace:  "namespace",
-			EntityName: "entity_name",
-			Group:      GroupThings,
-			Channel:    ChannelTwin,
-			Criterion:  CriterionMessages,
-			Action:     ActionSubscribe,
+		tests := map[string]struct {
+			topic *Topic
+			want  string
+		}{
+			"test_marshalJSON_with_all_entities": {
+				topic: &Topic{
+					Namespace:  "namespace",
+					EntityName: "test",
+					Group:      GroupThings,
+					Channel:    ChannelTwin,
+					Criterion:  CriterionMessages,
+					Action:     ActionSubscribe,
+				},
+				want: `"namespace/test/things/twin/messages/subscribe"`,
+			},
+			"test_marshalJSON_without_namespace": {
+				topic: &Topic{
+					EntityName: "test",
+					Group:      GroupThings,
+					Channel:    ChannelTwin,
+					Criterion:  CriterionMessages,
+					Action:     ActionSubscribe,
+				},
+				want: `"/test/things/twin/messages/subscribe"`,
+			},
+			"test_marshalJSON_without_name": {
+				topic: &Topic{
+					Namespace: "namespace",
+					Group:     GroupThings,
+					Channel:   ChannelTwin,
+					Criterion: CriterionMessages,
+					Action:    ActionSubscribe,
+				},
+				want: `"namespace//things/twin/messages/subscribe"`,
+			},
+			"test_marshalJSON_without_group": {
+				topic: &Topic{
+					Namespace:  "namespace",
+					EntityName: "test",
+					Channel:    ChannelTwin,
+					Criterion:  CriterionMessages,
+					Action:     ActionSubscribe,
+				},
+				want: `""`,
+			},
+			"test_marshalJSON_without_channel": {
+				topic: &Topic{
+					Namespace:  "namespace",
+					EntityName: "test",
+					Group:      GroupThings,
+					Criterion:  CriterionMessages,
+					Action:     ActionSubscribe,
+				},
+				want: `"namespace/test/things//messages/subscribe"`,
+			},
+			"test_marshalJSON_without_creation": {
+				topic: &Topic{
+					Namespace:  "namespace",
+					EntityName: "test",
+					Group:      GroupThings,
+					Channel:    ChannelTwin,
+					Action:     ActionSubscribe,
+				},
+				want: `"namespace/test/things/twin//subscribe"`,
+			},
+			"test_marshalJSON_without_action": {
+				topic: &Topic{
+					Namespace:  "namespace",
+					EntityName: "test",
+					Group:      GroupThings,
+					Channel:    ChannelTwin,
+					Criterion:  CriterionMessages,
+				},
+				want: `"namespace/test/things/twin/messages"`,
+			},
 		}
-		got, err := topic.MarshalJSON()
-		grp := "\"namespace/entity_name/" + string(GroupThings) +
-			"/" + string(ChannelTwin) + "/" + string(CriterionMessages) + "/" +
-			string(ActionSubscribe) + "\""
 
-		internal.AssertNil(t, err)
-		internal.AssertEqual(t, grp, string(got))
+		for testName, testCase := range tests {
+			t.Run(testName, func(t *testing.T) {
+				mTopic, _ := testCase.topic.MarshalJSON()
+				internal.AssertEqual(t, testCase.want, string(mTopic))
+			})
+		}
 	})
 }
 
-func TestTopicUnmarshalJSON(t *testing.T) {
-	tests := map[string]struct {
-		data                  string
-		wantErr               bool
-		onlyForUnmarshalError bool
-	}{
-		"test_topic_unmarshal_JSON_group_things": {
-			data: "namespace/entity_name/" +
-				string(GroupThings) + "/" +
-				string(ChannelTwin) + "/" +
-				string(CriterionMessages) + "/" +
-				string(ActionSubscribe),
-			wantErr:               false,
-			onlyForUnmarshalError: false,
-		},
-		"test_topic_unmarshal_JSON_group_policies": {
-			data: "namespace/entity_name/" +
-				string(GroupPolicies) + "/" +
-				string(CriterionCommands) + "/" +
-				string(ActionCreate),
-			wantErr:               false,
-			onlyForUnmarshalError: false,
-		},
-		"test_topic_unmarshal_JSON_insufficient_elements": {
-			data:                  "///",
-			wantErr:               true,
-			onlyForUnmarshalError: false,
-		},
-		"test_topic_unmarshal_JSON_group_things_missing_channel_for_things": {
-			data: "namespace/entity_name/" +
-				string(GroupThings) + "/" /*+ string(ChannelTwin) + "/"*/ +
-				string(CriterionMessages) + "/" +
-				string(ActionSubscribe),
-			wantErr:               true,
-			onlyForUnmarshalError: false,
-		},
-		"test_topic_unmarshal_JSON_group_things_insufficient_elements_for_things": {
-			data: "namespace/entity_name/" +
-				string(GroupThings) + "/" +
-				string(ChannelTwin) + "/" +
-				string(CriterionMessages),
-			wantErr:               true,
-			onlyForUnmarshalError: false,
-		},
-		"test_topic_unmarshal_JSON_topic_must_empty": {
-			data:                  "/////",
-			wantErr:               true,
-			onlyForUnmarshalError: false,
-		},
-		"test_topic_unmarshal_JSON_no_data": {
-			data:                  "",
-			wantErr:               true,
-			onlyForUnmarshalError: false,
-		},
-		"test_topic_unmarshal_JSON_only_for_internal_error": {
-			data: "namespace/entity_name/" +
-				string(GroupThings) + "/" +
-				string(ChannelTwin) + "/" +
-				string(CriterionMessages) + "/" +
-				string(ActionSubscribe),
-			wantErr:               true,
-			onlyForUnmarshalError: true,
-		},
-		"test_topic_unmarshal_JSON_set_configuration": {
-			data: "namespace/entity_name/" +
-				string(GroupThings) + "/" +
-				string(ChannelLive) + "/" +
-				string(CriterionMessages) + "/" +
-				"$set.configuration/name",
-			wantErr:               false,
-			onlyForUnmarshalError: false,
-		},
-		"test_topic_unmarshal_JSON_refresh_property": {
-			data: "namespace/entity_name/" +
-				string(GroupThings) + "/" +
-				string(ChannelLive) + "/" +
-				string(CriterionMessages) + "/" +
-				"$refresh.name",
-			wantErr:               false,
-			onlyForUnmarshalError: false,
-		},
-		"test_topic_unmarshal_JSON_refresh_action": {
-			data: "namespace/entity_name/" +
-				string(GroupThings) + "/" +
-				string(ChannelLive) + "/" +
-				string(CriterionMessages) + "/" +
-				"$refresh",
-			wantErr:               false,
-			onlyForUnmarshalError: false,
-		},
+func TestTopicValidUnmarshalJSON(t *testing.T) {
+	tests := []string{
+		`"namespace/test/things/twin/messages/subscribe"`,
+		`"namespace/test/policies/commands/create"`,
+		`"namespace/test/things/live/messages/$set.configuration/name"`,
+		`"namespace/test/things/live/messages/$refresh.name"`,
+		`"namespace/test/things/live/messages/$refresh"`,
+		`"namespace/test/things/live/messages/a"`,
 	}
 
-	for testName, testCase := range tests {
-		t.Run(testName, func(t *testing.T) {
-			topic := Topic{}
-			defer func() {
-				if r := recover(); r != nil {
-					if testCase.wantErr {
-						t.Logf("Topic.UnmarshalJSON() %v", r)
-					} else {
-						t.Errorf("Topic.UnmarshalJSON() unexpected error %v", r)
-					}
-				}
-			}()
-			var err error
-			if testCase.onlyForUnmarshalError {
-				err = topic.UnmarshalJSON([]byte(nil))
-			} else {
-				err = topic.UnmarshalJSON([]byte("\"" + testCase.data + "\""))
-			}
-			if err != nil {
-				if testCase.wantErr {
-					t.Logf("Topic.UnmarshalJSON() error = %v", err)
-					return
-				}
-				t.Errorf("Topic.UnmarshalJSON() unexpected error = %v", err)
-				return
-			}
-			if topic.String() == "" {
-				if testCase.wantErr {
-					t.Logf("Topic.UnmarshalJSON() topic is empty")
-					return
-				}
-				t.Errorf("Topic.UnmarshalJSON() unexpected empty topic")
-				return
-			}
-			if topic.String() != testCase.data {
-				t.Errorf("Topic.UnmarshalJSON() want = %v, got %v", topic.String(), testCase.data)
-				return
-			}
-		})
+	var topic Topic
+	for _, test := range tests {
+		topic.UnmarshalJSON([]byte(test))
+		internal.AssertEqual(t, test, fmt.Sprintf("%q", topic.String()))
+	}
+}
+
+func TestTopicInvalidUnmarshalJSON(t *testing.T) {
+	tests := []string{
+		`"//////"`,
+		`"/////"`,
+		`"namespace/name/"`,
+		`"namespace/name"`,
+		`"namespace/name/things/live/events//create"`,
+	}
+
+	var topic Topic
+	for _, test := range tests {
+		err := topic.UnmarshalJSON([]byte(test))
+		fmt.Println(err)
+		internal.AssertNotNil(t, err)
 	}
 }
 
 func TestTopicNamespace(t *testing.T) {
 	var (
-		testValidNamespace    = "test.namespace"
-		testInvalidNamespace  = "test:namespace"
-		testValidEntityName   = "test.name"
+		testValidNamespace    = "namespace"
+		testInvalidNamespace  = ":namespace"
+		testValidEntityName   = "test"
 		testInvalidEntityName = "test§name"
 	)
 
@@ -237,37 +211,37 @@ func TestTopicNamespace(t *testing.T) {
 		wantErr    error
 	}{
 		"test_topic_unmarshal_JSON_valid_namespace_entity_name": {
-			data:       testValidNamespace + "/" + testValidEntityName + "/things/twin/retrieve",
+			data:       `"namespace/test/things/twin/retrieve"`,
 			namespace:  testValidNamespace,
 			entityName: testValidEntityName,
 			wantErr:    nil,
 		},
 		"test_topic_unmarshal_JSON_empty_namespace_valid_entity_name": {
-			data:       TopicPlaceholder + "/" + testValidEntityName + "/things/twin/retrieve",
+			data:       `"_/test/things/twin/retrieve"`,
 			namespace:  TopicPlaceholder,
 			entityName: testValidEntityName,
 			wantErr:    nil,
 		},
 		"test_topic_unmarshal_JSON_valid_namespace_empty_entity_name": {
-			data:       testValidNamespace + "/" + TopicPlaceholder + "/things/twin/retrieve",
+			data:       `"namespace/_/things/twin/retrieve"`,
 			namespace:  testValidNamespace,
 			entityName: TopicPlaceholder,
 			wantErr:    nil,
 		},
 		"test_topic_unmarshal_JSON_empty_namespace_empty_entity_name": {
-			data:       TopicPlaceholder + "/" + TopicPlaceholder + "/things/twin/retrieve",
+			data:       `"_/_/things/twin/retrieve"`,
 			namespace:  TopicPlaceholder,
 			entityName: TopicPlaceholder,
 			wantErr:    nil,
 		},
 		"test_topic_unmarshal_JSON_invalid_namespace": {
-			data:       testInvalidNamespace + "/" + testValidEntityName + "/things/twin/retrieve",
+			data:       `":namespace/test/things/twin/retrieve"`,
 			namespace:  "",
 			entityName: "",
 			wantErr:    errors.New("invalid topic namespaced ID, namespace: " + testInvalidNamespace + ", entity name: " + testValidEntityName),
 		},
 		"test_topic_unmarshal_JSON_invalid_entity_name": {
-			data:       testValidNamespace + "/" + testInvalidEntityName + "/things/twin/retrieve",
+			data:       `"namespace/test§name/things/twin/retrieve"`,
 			namespace:  "",
 			entityName: "",
 			wantErr:    errors.New("invalid topic namespaced ID, namespace: " + testValidNamespace + ", entity name: " + testInvalidEntityName),
@@ -277,7 +251,7 @@ func TestTopicNamespace(t *testing.T) {
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
 			topic := Topic{}
-			err := topic.UnmarshalJSON([]byte("\"" + testCase.data + "\""))
+			err := topic.UnmarshalJSON([]byte(testCase.data))
 			internal.AssertError(t, testCase.wantErr, err)
 			internal.AssertEqual(t, testCase.namespace, topic.Namespace)
 			internal.AssertEqual(t, testCase.entityName, topic.EntityName)
@@ -288,17 +262,31 @@ func TestTopicNamespace(t *testing.T) {
 func TestTopicWithNamespace(t *testing.T) {
 	t.Run("TestTopicWithNamespace", func(t *testing.T) {
 		arg := "namespace"
-		topic := Topic{}
+		topic := Topic{
+			EntityName: "test",
+			Group:      GroupThings,
+			Channel:    ChannelTwin,
+			Criterion:  CriterionCommands,
+			Action:     ActionCreate,
+		}
 		got := topic.WithNamespace(arg)
+		internal.AssertEqual(t, "namespace/test/things/twin/commands/create", got.String())
 		internal.AssertEqual(t, arg, got.Namespace)
 	})
 }
 
 func TestTopicWithEntityName(t *testing.T) {
 	t.Run("TestTopicWithEntityName", func(t *testing.T) {
-		arg := "EntityName"
-		topic := Topic{}
+		arg := "test"
+		topic := Topic{
+			Namespace: "namespace",
+			Group:     GroupThings,
+			Channel:   ChannelTwin,
+			Criterion: CriterionCommands,
+			Action:    ActionCreate,
+		}
 		got := topic.WithEntityName(arg)
+		internal.AssertEqual(t, "namespace/test/things/twin/commands/create", got.String())
 		internal.AssertEqual(t, arg, got.EntityName)
 	})
 }
@@ -306,8 +294,15 @@ func TestTopicWithEntityName(t *testing.T) {
 func TestTopicWithGroup(t *testing.T) {
 	t.Run("TestTopicWithGroup", func(t *testing.T) {
 		arg := GroupThings
-		topic := Topic{}
+		topic := Topic{
+			Namespace:  "namespace",
+			EntityName: "test",
+			Channel:    ChannelTwin,
+			Criterion:  CriterionCommands,
+			Action:     ActionCreate,
+		}
 		got := topic.WithGroup(arg)
+		internal.AssertEqual(t, "namespace/test/things/twin/commands/create", got.String())
 		internal.AssertEqual(t, arg, got.Group)
 	})
 }
@@ -315,26 +310,47 @@ func TestTopicWithGroup(t *testing.T) {
 func TestTopicWithChannel(t *testing.T) {
 	t.Run("TestTopicWithChannel", func(t *testing.T) {
 		arg := ChannelTwin
-		topic := Topic{}
+		topic := Topic{
+			Namespace:  "namespace",
+			EntityName: "test",
+			Group:      GroupThings,
+			Criterion:  CriterionCommands,
+			Action:     ActionCreate,
+		}
 		got := topic.WithChannel(arg)
+		internal.AssertEqual(t, "namespace/test/things/twin/commands/create", got.String())
 		internal.AssertEqual(t, arg, got.Channel)
 	})
 }
 
 func TestTopicWithCriterion(t *testing.T) {
 	t.Run("TestTopicWithCriterion", func(t *testing.T) {
-		arg := CriterionMessages
-		topic := Topic{}
+		arg := CriterionCommands
+		topic := Topic{
+			Namespace:  "namespace",
+			EntityName: "test",
+			Group:      GroupThings,
+			Channel:    ChannelTwin,
+			Action:     ActionCreate,
+		}
 		got := topic.WithCriterion(arg)
+		internal.AssertEqual(t, "namespace/test/things/twin/commands/create", got.String())
 		internal.AssertEqual(t, arg, got.Criterion)
 	})
 }
 
 func TestTopicWithAction(t *testing.T) {
 	t.Run("TestTopicWithAction", func(t *testing.T) {
-		arg := ActionSubscribe
-		topic := Topic{}
+		arg := ActionCreate
+		topic := Topic{
+			Namespace:  "namespace",
+			EntityName: "test",
+			Group:      GroupThings,
+			Channel:    ChannelTwin,
+			Criterion:  CriterionCommands,
+		}
 		got := topic.WithAction(arg)
+		internal.AssertEqual(t, "namespace/test/things/twin/commands/create", got.String())
 		internal.AssertEqual(t, arg, got.Action)
 	})
 }


### PR DESCRIPTION
According the specification (https://www.eclipse.org/ditto/protocol-specification-topic.html#messages-criterion-actions) for messages creation, the action segment can be freely chosen.

Signed-off-by: Antonia Trifonova antonia.trifonova@bosch.io